### PR TITLE
feat: add input token, cache token, session, and verified sync achievements

### DIFF
--- a/apps/web/__tests__/unit/achievements.test.ts
+++ b/apps/web/__tests__/unit/achievements.test.ts
@@ -5,8 +5,13 @@ function makeStats(overrides: Partial<AchievementStats> = {}): AchievementStats 
   return {
     totalCost: 0,
     totalOutputTokens: 0,
+    totalInputTokens: 0,
+    totalCacheTokens: 0,
+    totalSessions: 0,
+    maxDailyCost: 0,
     streak: 0,
     syncCount: 0,
+    verifiedSyncCount: 0,
     ...overrides,
   };
 }
@@ -117,5 +122,113 @@ describe("100m-output", () => {
 
   it("earned at exactly 100,000,000 tokens", () => {
     expect(badge.check(makeStats({ totalOutputTokens: 100_000_000 }))).toBe(true);
+  });
+});
+
+describe("1m-input", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "1m-input")!;
+
+  it("not earned at 999,999 input tokens", () => {
+    expect(badge.check(makeStats({ totalInputTokens: 999_999 }))).toBe(false);
+  });
+
+  it("earned at exactly 1,000,000 input tokens", () => {
+    expect(badge.check(makeStats({ totalInputTokens: 1_000_000 }))).toBe(true);
+  });
+});
+
+describe("10m-input", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "10m-input")!;
+
+  it("not earned at 9,999,999 input tokens", () => {
+    expect(badge.check(makeStats({ totalInputTokens: 9_999_999 }))).toBe(false);
+  });
+
+  it("earned at exactly 10,000,000 input tokens", () => {
+    expect(badge.check(makeStats({ totalInputTokens: 10_000_000 }))).toBe(true);
+  });
+});
+
+describe("100m-input", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "100m-input")!;
+
+  it("not earned at 99,999,999 input tokens", () => {
+    expect(badge.check(makeStats({ totalInputTokens: 99_999_999 }))).toBe(false);
+  });
+
+  it("earned at exactly 100,000,000 input tokens", () => {
+    expect(badge.check(makeStats({ totalInputTokens: 100_000_000 }))).toBe(true);
+  });
+});
+
+describe("1b-cache", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "1b-cache")!;
+
+  it("not earned at 999,999,999 cache tokens", () => {
+    expect(badge.check(makeStats({ totalCacheTokens: 999_999_999 }))).toBe(false);
+  });
+
+  it("earned at exactly 1,000,000,000 cache tokens", () => {
+    expect(badge.check(makeStats({ totalCacheTokens: 1_000_000_000 }))).toBe(true);
+  });
+});
+
+describe("5b-cache", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "5b-cache")!;
+
+  it("not earned at 4,999,999,999 cache tokens", () => {
+    expect(badge.check(makeStats({ totalCacheTokens: 4_999_999_999 }))).toBe(false);
+  });
+
+  it("earned at exactly 5,000,000,000 cache tokens", () => {
+    expect(badge.check(makeStats({ totalCacheTokens: 5_000_000_000 }))).toBe(true);
+  });
+});
+
+describe("20b-cache", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "20b-cache")!;
+
+  it("not earned at 19,999,999,999 cache tokens", () => {
+    expect(badge.check(makeStats({ totalCacheTokens: 19_999_999_999 }))).toBe(false);
+  });
+
+  it("earned at exactly 20,000,000,000 cache tokens", () => {
+    expect(badge.check(makeStats({ totalCacheTokens: 20_000_000_000 }))).toBe(true);
+  });
+});
+
+describe("session-surge", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "session-surge")!;
+
+  it("not earned at 999 sessions", () => {
+    expect(badge.check(makeStats({ totalSessions: 999 }))).toBe(false);
+  });
+
+  it("earned at exactly 1,000 sessions", () => {
+    expect(badge.check(makeStats({ totalSessions: 1_000 }))).toBe(true);
+  });
+});
+
+describe("power-session", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "power-session")!;
+
+  it("not earned with max daily cost of $99.99", () => {
+    expect(badge.check(makeStats({ maxDailyCost: 99.99 }))).toBe(false);
+  });
+
+  it("earned with max daily cost of exactly $100", () => {
+    expect(badge.check(makeStats({ maxDailyCost: 100 }))).toBe(true);
+  });
+});
+
+describe("verified-contributor", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "verified-contributor")!;
+
+  it("not earned at 49 verified syncs", () => {
+    expect(badge.check(makeStats({ verifiedSyncCount: 49 }))).toBe(false);
+  });
+
+  it("earned at exactly 50 verified syncs", () => {
+    expect(badge.check(makeStats({ verifiedSyncCount: 50 }))).toBe(true);
   });
 });

--- a/apps/web/lib/achievements.ts
+++ b/apps/web/lib/achievements.ts
@@ -3,8 +3,13 @@ import { getServiceClient } from "@/lib/supabase/service";
 export interface AchievementStats {
   totalCost: number;
   totalOutputTokens: number;
+  totalInputTokens: number;
+  totalCacheTokens: number;
+  totalSessions: number;
+  maxDailyCost: number;
   streak: number;
   syncCount: number;
+  verifiedSyncCount: number;
 }
 
 export interface AchievementDef {
@@ -72,6 +77,69 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     emoji: "\u{1F30B}",
     check: (s) => s.totalOutputTokens >= 100_000_000,
   },
+  {
+    slug: "1m-input",
+    title: "1M Input",
+    description: "Process 1 million input tokens",
+    emoji: "\u{2328}\u{FE0F}",
+    check: (s) => s.totalInputTokens >= 1_000_000,
+  },
+  {
+    slug: "10m-input",
+    title: "10M Input",
+    description: "Process 10 million input tokens",
+    emoji: "\u{1F4D6}",
+    check: (s) => s.totalInputTokens >= 10_000_000,
+  },
+  {
+    slug: "100m-input",
+    title: "100M Input",
+    description: "Process 100 million input tokens",
+    emoji: "\u{1F9E0}",
+    check: (s) => s.totalInputTokens >= 100_000_000,
+  },
+  {
+    slug: "1b-cache",
+    title: "1B Cached",
+    description: "Save 1 billion tokens through prompt caching",
+    emoji: "\u{1F4BE}",
+    check: (s) => s.totalCacheTokens >= 1_000_000_000,
+  },
+  {
+    slug: "5b-cache",
+    title: "5B Cached",
+    description: "Save 5 billion tokens through prompt caching",
+    emoji: "\u{1F4BF}",
+    check: (s) => s.totalCacheTokens >= 5_000_000_000,
+  },
+  {
+    slug: "20b-cache",
+    title: "20B Cached",
+    description: "Save 20 billion tokens through prompt caching",
+    emoji: "\u{1F5C4}\u{FE0F}",
+    check: (s) => s.totalCacheTokens >= 20_000_000_000,
+  },
+  {
+    slug: "session-surge",
+    title: "Session Surge",
+    description: "Complete 1,000 total sessions",
+    emoji: "\u{1F4AA}",
+    check: (s) => s.totalSessions >= 1_000,
+  },
+  {
+    slug: "power-session",
+    title: "Power Session",
+    description: "Spend $100 in a single day",
+    emoji: "\u{1F4B0}",
+    check: (s) => s.maxDailyCost >= 100,
+  },
+  {
+    slug: "verified-contributor",
+    title: "Verified Contributor",
+    description: "Sync 50 verified entries from the CLI",
+    emoji: "\u{2705}",
+    check: (s) => s.verifiedSyncCount >= 50,
+  },
 ];
 
 export async function checkAndAwardAchievements(userId: string): Promise<void> {
@@ -80,7 +148,10 @@ export async function checkAndAwardAchievements(userId: string): Promise<void> {
   // Fetch earned slugs and aggregate stats in parallel
   const [{ data: earned }, { data: usageRows }, streakResult] = await Promise.all([
     db.from("user_achievements").select("achievement_slug").eq("user_id", userId),
-    db.from("daily_usage").select("cost_usd, output_tokens").eq("user_id", userId),
+    db
+      .from("daily_usage")
+      .select("cost_usd, output_tokens, input_tokens, cache_creation_tokens, cache_read_tokens, session_count, is_verified")
+      .eq("user_id", userId),
     db.rpc("calculate_user_streak", { p_user_id: userId }),
   ]);
 
@@ -89,8 +160,14 @@ export async function checkAndAwardAchievements(userId: string): Promise<void> {
   const stats: AchievementStats = {
     totalCost: usageRows?.reduce((s, r) => s + Number(r.cost_usd), 0) ?? 0,
     totalOutputTokens: usageRows?.reduce((s, r) => s + Number(r.output_tokens), 0) ?? 0,
+    totalInputTokens: usageRows?.reduce((s, r) => s + Number(r.input_tokens), 0) ?? 0,
+    totalCacheTokens:
+      usageRows?.reduce((s, r) => s + Number(r.cache_creation_tokens) + Number(r.cache_read_tokens), 0) ?? 0,
+    totalSessions: usageRows?.reduce((s, r) => s + Number(r.session_count), 0) ?? 0,
+    maxDailyCost: usageRows?.reduce((max, r) => Math.max(max, Number(r.cost_usd)), 0) ?? 0,
     streak: (streakResult.data as number) ?? 0,
     syncCount: usageRows?.length ?? 0,
+    verifiedSyncCount: usageRows?.reduce((s, r) => s + (r.is_verified ? Number(r.session_count) : 0), 0) ?? 0,
   };
 
   const newAwards = ACHIEVEMENTS.filter(


### PR DESCRIPTION
Extends AchievementStats with new fields and adds 9 new achievement definitions: 1M/10M/100M input tokens, 1B/10B/100B cached tokens, Session Surge (1k sessions), Power Session ($100/day), and Verified Contributor (50 verified syncs). Updates checkAndAwardAchievements to fetch and aggregate the additional columns from daily_usage and includes corresponding unit tests.

<details>
  <summary><b>Screenshot</b> (Click to expand)</summary>

<img width="935" height="131" alt="image" src="https://github.com/user-attachments/assets/2d0b282a-b292-4f75-8a76-b2d051fef93d" />
</details>

Tested this locally by running a Straude instance and submitting fake data via API to trigger achievements.

Regarding numbers in achievement conditions:
- I've picked same 1M/10M/100M for input tokens
- $100 session is per day, as most users have less in their posts, so it could be challenging
- Given that amount of cached tokens generally pretty large, I used ~~1B/10B/100B~~ 1B/5B/20B (not sure if it's small enough)

For cached token thresholds I'd look in prod DB to see current numbers and adjust if necessary.

**UPD:**
I've checked my CC usage stats, and reaching 100B could take ~4 years for me with current usage speed, so I decided to change tiers to 1B/5B/20B. Though it's still worth checking the DB data to see if these numbers are achievable in a reasonable amount of time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five new achievement categories with tiered milestones: Input Token Milestones, Cache Token Milestones, Session Surge, Power User, and Verified Contributor badges.

* **Tests**
  * Added comprehensive tests covering earned and not-earned scenarios for all new badge tiers and thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->