### PR TITLE
feat: social achievement badges + trigger-based achievement filtering

### DIFF
--- a/apps/web/__tests__/unit/achievements.test.ts
+++ b/apps/web/__tests__/unit/achievements.test.ts
@@ -12,6 +12,10 @@ function makeStats(overrides: Partial<AchievementStats> = {}): AchievementStats 
     streak: 0,
     syncCount: 0,
     verifiedSyncCount: 0,
+    kudosReceived: 0,
+    kudosSent: 0,
+    commentsReceived: 0,
+    commentsSent: 0,
     ...overrides,
   };
 }
@@ -26,6 +30,24 @@ describe("achievement definitions", () => {
     const stats = makeStats();
     const earned = ACHIEVEMENTS.filter((a) => a.check(stats));
     expect(earned).toHaveLength(0);
+  });
+
+  it("every achievement has a valid trigger", () => {
+    for (const a of ACHIEVEMENTS) {
+      expect(["usage", "kudos", "comment"]).toContain(a.trigger);
+    }
+  });
+
+  it("has 17 usage achievements", () => {
+    expect(ACHIEVEMENTS.filter((a) => a.trigger === "usage")).toHaveLength(17);
+  });
+
+  it("has 8 kudos achievements", () => {
+    expect(ACHIEVEMENTS.filter((a) => a.trigger === "kudos")).toHaveLength(8);
+  });
+
+  it("has 8 comment achievements", () => {
+    expect(ACHIEVEMENTS.filter((a) => a.trigger === "comment")).toHaveLength(8);
   });
 });
 
@@ -230,5 +252,197 @@ describe("verified-contributor", () => {
 
   it("earned at exactly 50 verified syncs", () => {
     expect(badge.check(makeStats({ verifiedSyncCount: 50 }))).toBe(true);
+  });
+});
+
+describe("kudos-received-1", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-received-1")!;
+
+  it("not earned with 0 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 0 }))).toBe(false);
+  });
+
+  it("earned with 1 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 1 }))).toBe(true);
+  });
+});
+
+describe("kudos-received-25", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-received-25")!;
+
+  it("not earned with 24 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 24 }))).toBe(false);
+  });
+
+  it("earned with exactly 25 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 25 }))).toBe(true);
+  });
+});
+
+describe("kudos-received-100", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-received-100")!;
+
+  it("not earned with 99 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 99 }))).toBe(false);
+  });
+
+  it("earned with exactly 100 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 100 }))).toBe(true);
+  });
+});
+
+describe("kudos-received-500", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-received-500")!;
+
+  it("not earned with 499 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 499 }))).toBe(false);
+  });
+
+  it("earned with exactly 500 kudos received", () => {
+    expect(badge.check(makeStats({ kudosReceived: 500 }))).toBe(true);
+  });
+});
+
+describe("kudos-sent-1", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-sent-1")!;
+
+  it("not earned with 0 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 0 }))).toBe(false);
+  });
+
+  it("earned with 1 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 1 }))).toBe(true);
+  });
+});
+
+describe("kudos-sent-25", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-sent-25")!;
+
+  it("not earned with 24 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 24 }))).toBe(false);
+  });
+
+  it("earned with exactly 25 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 25 }))).toBe(true);
+  });
+});
+
+describe("kudos-sent-100", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-sent-100")!;
+
+  it("not earned with 99 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 99 }))).toBe(false);
+  });
+
+  it("earned with exactly 100 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 100 }))).toBe(true);
+  });
+});
+
+describe("kudos-sent-500", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "kudos-sent-500")!;
+
+  it("not earned with 499 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 499 }))).toBe(false);
+  });
+
+  it("earned with exactly 500 kudos sent", () => {
+    expect(badge.check(makeStats({ kudosSent: 500 }))).toBe(true);
+  });
+});
+
+describe("comments-received-1", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-received-1")!;
+
+  it("not earned with 0 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 0 }))).toBe(false);
+  });
+
+  it("earned with 1 comment received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 1 }))).toBe(true);
+  });
+});
+
+describe("comments-received-25", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-received-25")!;
+
+  it("not earned with 24 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 24 }))).toBe(false);
+  });
+
+  it("earned with exactly 25 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 25 }))).toBe(true);
+  });
+});
+
+describe("comments-received-100", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-received-100")!;
+
+  it("not earned with 99 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 99 }))).toBe(false);
+  });
+
+  it("earned with exactly 100 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 100 }))).toBe(true);
+  });
+});
+
+describe("comments-received-500", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-received-500")!;
+
+  it("not earned with 499 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 499 }))).toBe(false);
+  });
+
+  it("earned with exactly 500 comments received", () => {
+    expect(badge.check(makeStats({ commentsReceived: 500 }))).toBe(true);
+  });
+});
+
+describe("comments-sent-1", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-sent-1")!;
+
+  it("not earned with 0 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 0 }))).toBe(false);
+  });
+
+  it("earned with 1 comment sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 1 }))).toBe(true);
+  });
+});
+
+describe("comments-sent-25", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-sent-25")!;
+
+  it("not earned with 24 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 24 }))).toBe(false);
+  });
+
+  it("earned with exactly 25 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 25 }))).toBe(true);
+  });
+});
+
+describe("comments-sent-100", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-sent-100")!;
+
+  it("not earned with 99 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 99 }))).toBe(false);
+  });
+
+  it("earned with exactly 100 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 100 }))).toBe(true);
+  });
+});
+
+describe("comments-sent-500", () => {
+  const badge = ACHIEVEMENTS.find((a) => a.slug === "comments-sent-500")!;
+
+  it("not earned with 499 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 499 }))).toBe(false);
+  });
+
+  it("earned with exactly 500 comments sent", () => {
+    expect(badge.check(makeStats({ commentsSent: 500 }))).toBe(true);
   });
 });

--- a/apps/web/app/api/posts/[id]/kudos/route.ts
+++ b/apps/web/app/api/posts/[id]/kudos/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { checkAndAwardAchievements } from "@/lib/achievements";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -23,20 +24,30 @@ export async function POST(_request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
+  // Fetch post owner for notifications and achievements
+  const { data: post } = !error
+    ? await supabase
+        .from("posts")
+        .select("user_id")
+        .eq("id", id)
+        .single()
+    : { data: null };
+
   // Insert kudos notification (skip self-kudos)
+  if (!error && post && post.user_id !== user.id) {
+    await supabase.from("notifications").insert({
+      user_id: post.user_id,
+      actor_id: user.id,
+      type: "kudos",
+      post_id: id,
+    });
+  }
+
+  // Award social achievements (fire-and-forget, only on INSERT not DELETE)
   if (!error) {
-    const { data: post } = await supabase
-      .from("posts")
-      .select("user_id")
-      .eq("id", id)
-      .single();
+    checkAndAwardAchievements(user.id, "kudos").catch(() => {});
     if (post && post.user_id !== user.id) {
-      await supabase.from("notifications").insert({
-        user_id: post.user_id,
-        actor_id: user.id,
-        type: "kudos",
-        post_id: id,
-      });
+      checkAndAwardAchievements(post.user_id, "kudos").catch(() => {});
     }
   }
 

--- a/apps/web/app/api/usage/submit/route.ts
+++ b/apps/web/app/api/usage/submit/route.ts
@@ -159,7 +159,7 @@ export async function POST(request: Request) {
     });
   }
 
-  checkAndAwardAchievements(userId).catch(() => {});
+  checkAndAwardAchievements(userId, "usage").catch(() => {});
 
   return NextResponse.json({ results } satisfies UsageSubmitResponse);
 }

--- a/apps/web/lib/achievements.ts
+++ b/apps/web/lib/achievements.ts
@@ -1,5 +1,7 @@
 import { getServiceClient } from "@/lib/supabase/service";
 
+export type AchievementTrigger = "usage" | "kudos" | "comment";
+
 export interface AchievementStats {
   totalCost: number;
   totalOutputTokens: number;
@@ -10,6 +12,10 @@ export interface AchievementStats {
   streak: number;
   syncCount: number;
   verifiedSyncCount: number;
+  kudosReceived: number;
+  kudosSent: number;
+  commentsReceived: number;
+  commentsSent: number;
 }
 
 export interface AchievementDef {
@@ -17,6 +23,7 @@ export interface AchievementDef {
   title: string;
   description: string;
   emoji: string;
+  trigger: AchievementTrigger;
   check: (stats: AchievementStats) => boolean;
 }
 
@@ -26,6 +33,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "First Sync",
     description: "Push your first session",
     emoji: "\u{1F331}",
+    trigger: "usage",
     check: (s) => s.syncCount >= 1,
   },
   {
@@ -33,6 +41,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "7-Day Streak",
     description: "Log 7 days in a row",
     emoji: "\u{1F525}",
+    trigger: "usage",
     check: (s) => s.streak >= 7,
   },
   {
@@ -40,6 +49,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "30-Day Streak",
     description: "Log 30 days in a row",
     emoji: "\u{1F3C6}",
+    trigger: "usage",
     check: (s) => s.streak >= 30,
   },
   {
@@ -47,6 +57,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "$100 Club",
     description: "Spend $100 lifetime",
     emoji: "\u{1F4B8}",
+    trigger: "usage",
     check: (s) => s.totalCost >= 100,
   },
   {
@@ -54,6 +65,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "Big Spender",
     description: "Spend $500 lifetime",
     emoji: "\u{1F911}",
+    trigger: "usage",
     check: (s) => s.totalCost >= 500,
   },
   {
@@ -61,6 +73,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "1M Output",
     description: "Generate 1 million output tokens",
     emoji: "\u{26A1}",
+    trigger: "usage",
     check: (s) => s.totalOutputTokens >= 1_000_000,
   },
   {
@@ -68,6 +81,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "10M Output",
     description: "Generate 10 million output tokens",
     emoji: "\u{1F680}",
+    trigger: "usage",
     check: (s) => s.totalOutputTokens >= 10_000_000,
   },
   {
@@ -75,6 +89,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "100M Output",
     description: "Generate 100 million output tokens",
     emoji: "\u{1F30B}",
+    trigger: "usage",
     check: (s) => s.totalOutputTokens >= 100_000_000,
   },
   {
@@ -82,6 +97,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "1M Input",
     description: "Process 1 million input tokens",
     emoji: "\u{1F4E5}",
+    trigger: "usage",
     check: (s) => s.totalInputTokens >= 1_000_000,
   },
   {
@@ -89,6 +105,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "10M Input",
     description: "Process 10 million input tokens",
     emoji: "\u{1F4DA}",
+    trigger: "usage",
     check: (s) => s.totalInputTokens >= 10_000_000,
   },
   {
@@ -96,6 +113,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "100M Input",
     description: "Process 100 million input tokens",
     emoji: "\u{1F9E0}",
+    trigger: "usage",
     check: (s) => s.totalInputTokens >= 100_000_000,
   },
   {
@@ -103,6 +121,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "1B Cache",
     description: "Use 1 billion cache tokens",
     emoji: "\u{1F4BE}",
+    trigger: "usage",
     check: (s) => s.totalCacheTokens >= 1_000_000_000,
   },
   {
@@ -110,6 +129,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "5B Cache",
     description: "Use 5 billion cache tokens",
     emoji: "\u{1F5C4}\uFE0F",
+    trigger: "usage",
     check: (s) => s.totalCacheTokens >= 5_000_000_000,
   },
   {
@@ -117,6 +137,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "20B Cache",
     description: "Use 20 billion cache tokens",
     emoji: "\u{1F3ED}",
+    trigger: "usage",
     check: (s) => s.totalCacheTokens >= 20_000_000_000,
   },
   {
@@ -124,6 +145,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "Session Surge",
     description: "Log 1,000 sessions",
     emoji: "\u{1F300}",
+    trigger: "usage",
     check: (s) => s.totalSessions >= 1_000,
   },
   {
@@ -131,6 +153,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "Power Session",
     description: "Spend $100 in a single day",
     emoji: "\u{1F4A5}",
+    trigger: "usage",
     check: (s) => s.maxDailyCost >= 100,
   },
   {
@@ -138,36 +161,200 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     title: "Verified Contributor",
     description: "Push 50 verified syncs",
     emoji: "\u{2705}",
+    trigger: "usage",
     check: (s) => s.verifiedSyncCount >= 50,
+  },
+  {
+    slug: "kudos-received-1",
+    title: "First Kudos",
+    description: "Receive your first kudos",
+    emoji: "\u{1F44D}",
+    trigger: "kudos",
+    check: (s) => s.kudosReceived >= 1,
+  },
+  {
+    slug: "kudos-received-25",
+    title: "Appreciated",
+    description: "Receive 25 kudos on your posts",
+    emoji: "\u{2B50}",
+    trigger: "kudos",
+    check: (s) => s.kudosReceived >= 25,
+  },
+  {
+    slug: "kudos-received-100",
+    title: "Community Favorite",
+    description: "Receive 100 kudos on your posts",
+    emoji: "\u{1F31F}",
+    trigger: "kudos",
+    check: (s) => s.kudosReceived >= 100,
+  },
+  {
+    slug: "kudos-received-500",
+    title: "Beloved",
+    description: "Receive 500 kudos on your posts",
+    emoji: "\u{1F49B}",
+    trigger: "kudos",
+    check: (s) => s.kudosReceived >= 500,
+  },
+  {
+    slug: "kudos-sent-1",
+    title: "First High Five",
+    description: "Give your first kudos",
+    emoji: "\u{1F64C}",
+    trigger: "kudos",
+    check: (s) => s.kudosSent >= 1,
+  },
+  {
+    slug: "kudos-sent-25",
+    title: "Supporter",
+    description: "Give 25 kudos to others",
+    emoji: "\u{1F91D}",
+    trigger: "kudos",
+    check: (s) => s.kudosSent >= 25,
+  },
+  {
+    slug: "kudos-sent-100",
+    title: "Kudos Giver",
+    description: "Give 100 kudos to others",
+    emoji: "\u{1F4AA}",
+    trigger: "kudos",
+    check: (s) => s.kudosSent >= 100,
+  },
+  {
+    slug: "kudos-sent-500",
+    title: "Hype Machine",
+    description: "Give 500 kudos to others",
+    emoji: "\u{1F514}",
+    trigger: "kudos",
+    check: (s) => s.kudosSent >= 500,
+  },
+  {
+    slug: "comments-received-1",
+    title: "First Reply",
+    description: "Receive your first comment",
+    emoji: "\u{1F4AC}",
+    trigger: "comment",
+    check: (s) => s.commentsReceived >= 1,
+  },
+  {
+    slug: "comments-received-25",
+    title: "Conversation Starter",
+    description: "Receive 25 comments on your posts",
+    emoji: "\u{1F5E3}\uFE0F",
+    trigger: "comment",
+    check: (s) => s.commentsReceived >= 25,
+  },
+  {
+    slug: "comments-received-100",
+    title: "Discussion Magnet",
+    description: "Receive 100 comments on your posts",
+    emoji: "\u{1F9F2}",
+    trigger: "comment",
+    check: (s) => s.commentsReceived >= 100,
+  },
+  {
+    slug: "comments-received-500",
+    title: "Town Square",
+    description: "Receive 500 comments on your posts",
+    emoji: "\u{1F4E2}",
+    trigger: "comment",
+    check: (s) => s.commentsReceived >= 500,
+  },
+  {
+    slug: "comments-sent-1",
+    title: "First Comment",
+    description: "Leave your first comment",
+    emoji: "\u{270D}\uFE0F",
+    trigger: "comment",
+    check: (s) => s.commentsSent >= 1,
+  },
+  {
+    slug: "comments-sent-25",
+    title: "Active Voice",
+    description: "Leave 25 comments",
+    emoji: "\u{1F4DD}",
+    trigger: "comment",
+    check: (s) => s.commentsSent >= 25,
+  },
+  {
+    slug: "comments-sent-100",
+    title: "Prolific Commenter",
+    description: "Leave 100 comments",
+    emoji: "\u{1F58A}\uFE0F",
+    trigger: "comment",
+    check: (s) => s.commentsSent >= 100,
+  },
+  {
+    slug: "comments-sent-500",
+    title: "Never Silent",
+    description: "Leave 500 comments",
+    emoji: "\u{1F3A4}",
+    trigger: "comment",
+    check: (s) => s.commentsSent >= 500,
   },
 ];
 
-export async function checkAndAwardAchievements(userId: string): Promise<void> {
+function fetchIf<T>(condition: boolean, fn: () => PromiseLike<T>): Promise<T | null> {
+  return condition ? Promise.resolve(fn()) : Promise.resolve(null);
+}
+
+/**
+ * Check and award achievements for a user, filtered by trigger type.
+ * Called fire-and-forget from API routes after relevant data changes.
+ *
+ * - "usage" trigger: called from POST /api/usage/submit
+ * - "kudos" trigger: called from POST /api/posts/[id]/kudos (for both giver and post owner)
+ * - "comment" trigger: called from POST /api/posts/[id]/comments (for the post owner)
+ */
+export async function checkAndAwardAchievements(
+  userId: string,
+  trigger?: AchievementTrigger,
+): Promise<void> {
   const db = getServiceClient();
 
-  // Fetch earned slugs, aggregated stats, and streak in parallel
-  const [{ data: earned }, rpcResult, streakResult] = await Promise.all([
-    db.from("user_achievements").select("achievement_slug").eq("user_id", userId),
-    db.rpc("get_achievement_stats", { p_user_id: userId }).single(),
-    db.rpc("calculate_user_streak", { p_user_id: userId }),
-  ]);
+  const candidates = trigger
+    ? ACHIEVEMENTS.filter((a) => a.trigger === trigger)
+    : ACHIEVEMENTS;
+
+  if (candidates.length === 0) return;
+
+  const { data: earned } = await db
+    .from("user_achievements")
+    .select("achievement_slug")
+    .eq("user_id", userId);
 
   const earnedSlugs = new Set(earned?.map((r) => r.achievement_slug) ?? []);
 
-  const rpcRow = rpcResult.data as Record<string, unknown> | null;
+  const needs = (...triggers: AchievementTrigger[]) =>
+    !trigger || triggers.includes(trigger);
+
+  const [usageResult, streakResult, socialResult] = await Promise.all([
+    fetchIf(needs("usage"), () => db.rpc("get_achievement_stats", { p_user_id: userId }).single()),
+    fetchIf(needs("usage"), () => db.rpc("calculate_user_streak", { p_user_id: userId })),
+    fetchIf(needs("kudos", "comment"), () => db.rpc("get_social_achievement_stats", { p_user_id: userId }).single()),
+  ]);
+
+  const usageRow = usageResult?.data as Record<string, unknown> | null;
+  const socialRow = socialResult?.data as Record<string, unknown> | null;
+
   const stats: AchievementStats = {
-    totalCost: Number(rpcRow?.total_cost ?? 0),
-    totalOutputTokens: Number(rpcRow?.total_output_tokens ?? 0),
-    totalInputTokens: Number(rpcRow?.total_input_tokens ?? 0),
-    totalCacheTokens: Number(rpcRow?.total_cache_tokens ?? 0),
-    totalSessions: Number(rpcRow?.total_sessions ?? 0),
-    maxDailyCost: Number(rpcRow?.max_daily_cost ?? 0),
-    streak: (streakResult.data as number) ?? 0,
-    syncCount: Number(rpcRow?.sync_count ?? 0),
-    verifiedSyncCount: Number(rpcRow?.verified_sync_count ?? 0),
+    totalCost: Number(usageRow?.total_cost ?? 0),
+    totalOutputTokens: Number(usageRow?.total_output_tokens ?? 0),
+    totalInputTokens: Number(usageRow?.total_input_tokens ?? 0),
+    totalCacheTokens: Number(usageRow?.total_cache_tokens ?? 0),
+    totalSessions: Number(usageRow?.total_sessions ?? 0),
+    maxDailyCost: Number(usageRow?.max_daily_cost ?? 0),
+    streak: (streakResult?.data as number) ?? 0,
+    syncCount: Number(usageRow?.sync_count ?? 0),
+    verifiedSyncCount: Number(usageRow?.verified_sync_count ?? 0),
+    // Self-interactions (kudos/comments on own posts) are counted intentionally.
+    kudosReceived: Number(socialRow?.kudos_received ?? 0),
+    kudosSent: Number(socialRow?.kudos_sent ?? 0),
+    commentsReceived: Number(socialRow?.comments_received ?? 0),
+    commentsSent: Number(socialRow?.comments_sent ?? 0),
   };
 
-  const newAwards = ACHIEVEMENTS.filter(
+  const newAwards = candidates.filter(
     (a) => !earnedSlugs.has(a.slug) && a.check(stats),
   );
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **16 social achievement badges.** Kudos Received (1/25/100/500), Kudos Given (1/25/100/500), Comments Received (1/25/100/500), Comments Sent (1/25/100/500). Each tier has a unique emoji. Category-prefixed slugs (`kudos-received-1`, `kudos-sent-25`, `comments-received-100`, `comments-sent-500`). Total badges: 33.
+- **`get_social_achievement_stats` Supabase RPC.** Aggregates `kudos_received`, `kudos_sent`, `comments_received`, and `comments_sent` in a single query. Service-role only, matching existing `get_achievement_stats` permission model.
+- **Trigger-based achievement filtering.** `checkAndAwardAchievements` now accepts an optional `trigger` parameter (`usage` | `kudos` | `comment`) to only check relevant achievements and call the appropriate RPC. Kudos/comment triggers skip the usage stats RPC and vice versa.
+- **Achievement checks wired into social routes.** Kudos POST checks achievements for both giver and post owner. Comments POST checks achievements for the post owner. All fire-and-forget.
 - **9 new achievement badges.** Input tokens (1M/10M/100M), cache tokens (1B/5B/20B), Session Surge (1,000 sessions), Power Session ($100/day), and Verified Contributor (50 verified syncs). Total badges: 17. Credit: @alexesprit PR #1.
 
 ### Changed

--- a/supabase/migrations/20260224_get_social_achievement_stats.sql
+++ b/supabase/migrations/20260224_get_social_achievement_stats.sql
@@ -1,0 +1,29 @@
+-- Aggregates social achievement stats for a user in a single query.
+-- Counts kudos received, kudos sent, comments received, and comments sent.
+-- Self-interactions (kudos/comments on own posts) are counted intentionally.
+CREATE OR REPLACE FUNCTION public.get_social_achievement_stats(p_user_id uuid)
+RETURNS TABLE (
+  kudos_received    bigint,
+  kudos_sent        bigint,
+  comments_received bigint,
+  comments_sent     bigint
+) LANGUAGE plpgsql STABLE SET search_path TO 'public' AS $$
+BEGIN
+  RETURN QUERY SELECT
+    (SELECT COUNT(*) FROM public.kudos k
+       JOIN public.posts p ON k.post_id = p.id
+       WHERE p.user_id = p_user_id)::bigint,
+    (SELECT COUNT(*) FROM public.kudos
+       WHERE user_id = p_user_id)::bigint,
+    (SELECT COUNT(*) FROM public.comments c
+       JOIN public.posts p ON c.post_id = p.id
+       WHERE p.user_id = p_user_id)::bigint,
+    (SELECT COUNT(*) FROM public.comments
+       WHERE user_id = p_user_id)::bigint;
+END; $$;
+
+-- Only service_role can call this (achievements are awarded server-side).
+REVOKE ALL ON FUNCTION public.get_social_achievement_stats(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_social_achievement_stats(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.get_social_achievement_stats(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_social_achievement_stats(uuid) TO service_role;


### PR DESCRIPTION
Add 16 new social achievement badges (kudos received/sent and comments received/sent, each at 1/25/100/500 thresholds). Wire achievement checks into kudos and comment routes for both the actor and the post owner.

- Add `get_social_achievement_stats` RPC (service_role only) aggregating kudos_received, kudos_sent, comments_received, comments_sent in one query
- Add `trigger` parameter to `checkAndAwardAchievements` to filter candidates and skip irrelevant RPCs (usage vs social paths)
- Wire fire-and-forget achievement checks into POST /kudos and POST /comments
- Add `trigger` field to all 33 achievement definitions
- Extend `AchievementStats` with four social counters
- Expand unit tests to cover all 16 new badges + trigger invariants

<img width="1006" height="571" alt="image" src="https://github.com/user-attachments/assets/0fd8794b-6ccc-4cb6-a80e-b78233242a02" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added social achievement badges for kudos sent/received and comments sent/received across multiple tier levels; achievement checks now run when social interactions occur.
  * Achievement checks can be scoped to interaction type to reduce unnecessary work.

* **Documentation**
  * Updated changelog and decision docs to describe the social achievement enhancements.

* **Tests**
  * Expanded unit tests covering new achievement triggers, thresholds, and stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->