### PR TITLE
fix: update achievement test counts to match current definitions

### DIFF
--- a/apps/web/__tests__/unit/achievements.test.ts
+++ b/apps/web/__tests__/unit/achievements.test.ts
@@ -12,6 +12,7 @@ function makeStats(overrides: Partial<AchievementStats> = {}): AchievementStats 
     streak: 0,
     syncCount: 0,
     verifiedSyncCount: 0,
+    syncsInFirstWeek: 0,
     kudosReceived: 0,
     kudosSent: 0,
     commentsReceived: 0,
@@ -39,8 +40,8 @@ describe("achievement definitions", () => {
     }
   });
 
-  it("has 17 usage achievements", () => {
-    expect(ACHIEVEMENTS.filter((a) => a.trigger === "usage")).toHaveLength(17);
+  it("has 18 usage achievements", () => {
+    expect(ACHIEVEMENTS.filter((a) => a.trigger === "usage")).toHaveLength(18);
   });
 
   it("has 8 kudos achievements", () => {


### PR DESCRIPTION
## Summary
- Bump usage achievement count assertion from 17 → 18 to match the current `ACHIEVEMENTS` array (a new usage achievement was added but the test wasn't updated)
- Add missing `syncsInFirstWeek: 0` to the `makeStats` helper in the achievements test so it fully satisfies the `AchievementStats` type

## Test plan
- [x] `bun vitest run __tests__/unit/achievements.test.ts` — all 81 tests pass
- [x] Full test suite (`bun run test` in `apps/web`) — 34 files, 370 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new achievement metric that tracks user synchronization activity during the first week.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->