### PR TITLE
fix: improve completeness ring visibility and tooltip

### DIFF
--- a/apps/web/components/app/feed/ActivityCard.tsx
+++ b/apps/web/components/app/feed/ActivityCard.tsx
@@ -83,16 +83,25 @@ function formatModels(
 }
 
 function CompletenessRing({ post }: { post: Post }) {
-  const steps = [post.title, post.description, post.images?.length].filter(Boolean).length;
+  const missing = [
+    !post.title && "title",
+    !post.description && "description",
+    !post.images?.length && "images",
+  ].filter(Boolean) as string[];
+  const steps = 3 - missing.length;
   const pct = 25 + steps * 25;
   const r = 7;
   const c = 2 * Math.PI * r;
+  const tooltip = missing.length === 0
+    ? "Post is complete"
+    : `Add ${missing.join(", ")} to complete this post`;
   return (
     <svg width="18" height="18" className="shrink-0" aria-label={`${pct}% complete`}>
-      <circle cx="9" cy="9" r={r} fill="none" stroke="currentColor" strokeWidth="2" className="text-border" />
+      <title>{tooltip}</title>
+      <circle cx="9" cy="9" r={r} fill="none" stroke="#e0e0e0" strokeWidth="2" />
       <circle
         cx="9" cy="9" r={r} fill="none" stroke="currentColor" strokeWidth="2"
-        className={pct === 100 ? "text-accent" : "text-muted"}
+        className="text-accent"
         strokeDasharray={c} strokeDashoffset={c * (1 - pct / 100)}
         transform="rotate(-90 9 9)"
       />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+- **Post completeness ring visibility.** Ring fill now always uses the accent color (regardless of completion level) with a light gray track, making it readable at all completion levels. Tooltip now lists only the missing fields (title, description, images) instead of a generic "complete your post" message.
 - **Timezone-aware streak calculation.** `calculate_user_streak` now uses the user's `timezone` column to compute "today" instead of UTC `CURRENT_DATE`. Previously, users behind UTC (e.g., PST) could see their streak appear broken near midnight because the server thought it was the next day. The 2-day timezone buffer hack is replaced with a proper 1-day grace period using the user's actual timezone.
 - **Sidebar and feed date display off by one day.** The sidebar "Latest Activities" dates and the feed `timeAgo` fallback used `posts.created_at` (UTC) instead of `daily_usage.date` (the user's local date). A post pushed at 10pm PST on Feb 27 would display as "Feb 28" because `created_at` was Feb 28 UTC. Both now prefer the usage date when available.
 - **Duplicate mention notifications on post edit.** Every PATCH to a post re-inserted mention notifications for all `@username` references in the description, even when only images or title changed. Now mention logic only runs when the description field is actually updated, and existing mention notifications for the post are checked before inserting — users who were already notified are skipped.


### PR DESCRIPTION
## Summary
- Track color changed from black (`text-border`) to light gray (`#e0e0e0`) so it's visible on the white background
- Fill color always uses `text-accent` (orange) instead of dark gray, making progress readable at all levels
- SVG `<title>` tooltip now lists only the missing fields (e.g. "Add images to complete this post") rather than a generic message

## Screenshots

**Before:** Barely visible it's a circular progress bar
<img width="103" height="30" alt="image" src="https://github.com/user-attachments/assets/f3f31aa0-df40-49c8-bea1-51b6d3a9849b" />

**After:** Visible + title to explain
<img width="107" height="33" alt="image" src="https://github.com/user-attachments/assets/82d15aae-e417-43bd-9860-6eef248f323c" />

## Test plan
- [x] Open the feed and find a post you own with missing fields — ring should show orange fill on light gray track
- [x] Hover the ring — tooltip should name only the missing fields
- [x] On a fully complete post, tooltip should read "Post is complete"