### PR TITLE
feat: notifications page with pagination, filtering, and badge sync

### DIFF
--- a/apps/web/app/(app)/notifications/page.tsx
+++ b/apps/web/app/(app)/notifications/page.tsx
@@ -1,0 +1,16 @@
+import { NotificationsList } from "@/components/app/notifications/NotificationsList";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Notifications" };
+
+export default function NotificationsPage() {
+  return (
+    <>
+      <header className="sticky top-0 z-10 flex h-16 items-center border-b border-border bg-background px-6">
+        <h3 className="text-lg font-medium">Notifications</h3>
+      </header>
+
+      <NotificationsList />
+    </>
+  );
+}

--- a/apps/web/app/api/notifications/route.ts
+++ b/apps/web/app/api/notifications/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-export async function GET() {
+const VALID_TYPES = new Set(["follow", "kudos", "comment", "mention"]);
+
+export async function GET(request: NextRequest) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -11,19 +13,37 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const [notificationsRes, unreadRes] = await Promise.all([
-    supabase
-      .from("notifications")
-      .select("*, actor:users!notifications_actor_id_fkey(username, avatar_url)")
-      .eq("user_id", user.id)
-      .order("created_at", { ascending: false })
-      .limit(20),
-    supabase
-      .from("notifications")
-      .select("id", { count: "exact", head: true })
-      .eq("user_id", user.id)
-      .eq("read", false),
-  ]);
+  const url = request.nextUrl;
+  const limit = Math.min(Math.max(Number(url.searchParams.get("limit")) || 20, 1), 50);
+  const offset = Math.max(Number(url.searchParams.get("offset")) || 0, 0);
+  const typeParam = url.searchParams.get("type");
+  const typeFilter = typeParam && VALID_TYPES.has(typeParam) ? typeParam : null;
+
+  let query = supabase
+    .from("notifications")
+    .select("*, actor:users!notifications_actor_id_fkey(username, avatar_url)")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (typeFilter) {
+    query = query.eq("type", typeFilter);
+  }
+
+  let countQuery = supabase
+    .from("notifications")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("read", false);
+
+  const [notificationsRes, unreadRes] = await Promise.all([query, countQuery]);
+
+  if (notificationsRes.error || unreadRes.error) {
+    return NextResponse.json(
+      { error: notificationsRes.error?.message ?? unreadRes.error?.message },
+      { status: 500 },
+    );
+  }
 
   return NextResponse.json({
     notifications: notificationsRes.data ?? [],

--- a/apps/web/components/app/notifications/NotificationsList.tsx
+++ b/apps/web/components/app/notifications/NotificationsList.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Avatar } from "@/components/ui/Avatar";
+import { cn } from "@/lib/utils/cn";
+import { timeAgo, notificationMessage, notificationHref } from "@/lib/utils/notifications";
+import type { Notification } from "@/types";
+
+const NOTIFICATION_TYPES = [
+  { value: null, label: "All" },
+  { value: "follow", label: "Follows" },
+  { value: "kudos", label: "Kudos" },
+  { value: "comment", label: "Comments" },
+  { value: "mention", label: "Mentions" },
+] as const;
+
+const PAGE_SIZE = 20;
+
+export function NotificationsList() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(true);
+  const loadingRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const notificationsLengthRef = useRef(0);
+
+  const fetchNotifications = useCallback(
+    async (offset: number, type: string | null, replace: boolean) => {
+      if (loadingRef.current) return;
+      loadingRef.current = true;
+      if (replace) setLoading(true);
+
+      const params = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        offset: String(offset),
+      });
+      if (type) params.set("type", type);
+
+      const res = await fetch(`/api/notifications?${params}`);
+      if (!res.ok) {
+        loadingRef.current = false;
+        setLoading(false);
+        return;
+      }
+
+      const data = await res.json();
+      const fetched: Notification[] = data.notifications ?? [];
+
+      setNotifications((prev) => (replace ? fetched : [...prev, ...fetched]));
+      setUnreadCount(data.unread_count ?? 0);
+      setHasMore(fetched.length >= PAGE_SIZE);
+      setLoading(false);
+      loadingRef.current = false;
+    },
+    [],
+  );
+
+  // Initial load and filter change
+  useEffect(() => {
+    setNotifications([]);
+    setHasMore(true);
+    fetchNotifications(0, typeFilter, true);
+  }, [typeFilter, fetchNotifications]);
+
+  // Keep length ref in sync so the observer can read it without being in deps
+  useEffect(() => {
+    notificationsLengthRef.current = notifications.length;
+  }, [notifications.length]);
+
+  // Infinite scroll via IntersectionObserver
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !loadingRef.current && hasMore) {
+          fetchNotifications(notificationsLengthRef.current, typeFilter, false);
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [typeFilter, hasMore, fetchNotifications]);
+
+  async function handleMarkAllRead() {
+    await fetch("/api/notifications", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ all: true }),
+    });
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    setUnreadCount(0);
+    window.dispatchEvent(new Event("notifications-updated"));
+  }
+
+  function handleMarkRead(id: string) {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    );
+    setUnreadCount((c) => Math.max(0, c - 1));
+    fetch("/api/notifications", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids: [id] }),
+    });
+    window.dispatchEvent(new Event("notifications-updated"));
+  }
+
+  return (
+    <div>
+      {/* Type filter tabs — matches leaderboard period tabs */}
+      <div className="flex items-center justify-between border-b border-border">
+        <div className="flex flex-1 justify-center overflow-x-auto">
+          {NOTIFICATION_TYPES.map(({ value, label }) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => setTypeFilter(value)}
+              className={cn(
+                "shrink-0 border-b-2 border-transparent px-4 py-3 text-sm font-semibold text-muted sm:px-5",
+                typeFilter === value && "border-b-accent text-accent",
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {unreadCount > 0 && (
+          <button
+            type="button"
+            onClick={handleMarkAllRead}
+            className="shrink-0 px-4 text-xs text-muted hover:text-foreground sm:px-6"
+          >
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {/* Notification list — matches search result items */}
+      {loading && notifications.length === 0 ? (
+        <div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 border-b border-border px-4 py-4 sm:px-6">
+              <div className="h-8 w-8 shrink-0 animate-pulse rounded-full bg-subtle" />
+              <div className="flex-1 overflow-hidden">
+                <p className="text-sm leading-snug">
+                  <span className="inline-block h-3.5 w-3/4 animate-pulse rounded bg-subtle" />
+                </p>
+                <p className="mt-0.5 text-xs">
+                  <span className="inline-block h-2.5 w-16 animate-pulse rounded bg-subtle" />
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : notifications.length === 0 ? (
+        <p className="px-6 py-12 text-center text-sm text-muted">
+          {typeFilter
+            ? `No ${NOTIFICATION_TYPES.find((t) => t.value === typeFilter)?.label.toLowerCase()} notifications`
+            : "No notifications yet"}
+        </p>
+      ) : (
+        <div>
+          {notifications.map((n) => (
+            <Link
+              key={n.id}
+              href={notificationHref(n)}
+              onClick={() => {
+                if (!n.read) handleMarkRead(n.id);
+              }}
+              className={cn(
+                "flex items-center gap-4 border-b border-border px-4 py-4 hover:bg-subtle sm:px-6",
+                !n.read && "bg-subtle/50",
+              )}
+            >
+              <Avatar
+                src={n.actor?.avatar_url ?? null}
+                size="sm"
+                fallback={n.actor?.username ?? "?"}
+              />
+              <div className="flex-1 overflow-hidden">
+                <p className="text-sm leading-snug">
+                  {notificationMessage(n)}
+                </p>
+                <p
+                  suppressHydrationWarning
+                  className="mt-0.5 text-xs text-muted"
+                >
+                  {timeAgo(n.created_at)}
+                </p>
+              </div>
+              {!n.read && (
+                <span className="h-2 w-2 shrink-0 rounded-full bg-accent" />
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Infinite scroll sentinel */}
+      <div ref={sentinelRef} className="h-px" />
+    </div>
+  );
+}

--- a/apps/web/lib/utils/notifications.ts
+++ b/apps/web/lib/utils/notifications.ts
@@ -1,0 +1,42 @@
+import type { Notification } from "@/types";
+
+export function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d`;
+  return `${Math.floor(days / 30)}mo`;
+}
+
+export function notificationMessage(n: Notification): string {
+  const actor = n.actor?.username ?? "Someone";
+  switch (n.type) {
+    case "follow":
+      return `${actor} started following you`;
+    case "kudos":
+      return `${actor} gave kudos to your post`;
+    case "comment":
+      return `${actor} commented on your post`;
+    case "mention":
+      return `${actor} mentioned you in a ${n.comment_id ? "comment" : "post"}`;
+    default:
+      return `${actor} interacted with you`;
+  }
+}
+
+export function notificationHref(n: Notification): string {
+  switch (n.type) {
+    case "follow":
+      return n.actor?.username ? `/u/${n.actor.username}` : "/notifications";
+    case "kudos":
+    case "comment":
+    case "mention":
+      return n.post_id ? `/post/${n.post_id}` : "/notifications";
+    default:
+      return "/notifications";
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,9 +25,9 @@ Streak freezes are now shipped (earned by enriching posts, extend grace window).
 - **Achievement chains**: Restructure the flat `ACHIEVEMENTS` array into progression quest lines with visible progress bars ("72% to 90-Day Streak").
 - **Ship Week countdown banner**: Show "4 days left — 3/5 synced" banner for users in their first week. The Ship Week achievement is live but the countdown UI is deferred.
 
-## Notifications Page
+## ~~Notifications Page~~ (shipped 2026-02-25)
 
-The dropdown shows the 20 most recent notifications. A dedicated `/notifications` page with pagination and filtering (by type) would be useful for users with high activity.
+Moved to Shipped section below.
 
 ## Create Post Page
 
@@ -110,6 +110,10 @@ Private or public groups where teams (company, OSS project, friend group) share 
 ### Admin Dashboard (2026-02-28)
 
 Internal dashboard at `/admin` for tracking the North Star Metric (cumulative spend), user activation funnel, growth metrics, and top users. Access restricted via `ADMIN_USER_IDS` env var. Four SECURITY DEFINER RPCs power the data. Charts via recharts (lazy-loaded). Future: add retention cohorts, revenue per user trends, and model usage breakdown.
+
+### Notifications Page (2026-02-25)
+
+Dedicated `/notifications` page with infinite scroll pagination, type filtering (All/Follows/Kudos/Comments/Mentions), and mark-all-as-read. API extended with `?limit`, `?offset`, and `?type` query params. "See all notifications" link added to the header dropdown.
 
 ### Achievements & Badges (2026-02-22, expanded 2026-02-24)
 


### PR DESCRIPTION
## Summary
- New `/notifications` page with infinite scroll (20/page), type filter tabs (All / Follows / Kudos / Comments / Mentions), mark-all-as-read, and per-notification mark-as-read on click
- Notification helpers (`timeAgo`, `notificationMessage`, `notificationHref`) extracted to `lib/utils/notifications.ts`, shared between the dropdown and the full page
- `GET /api/notifications` extended with `?limit`, `?offset`, and `?type` query params (backward-compatible)
- `notifications-updated` custom event keeps the TopHeader unread dot in sync when notifications are read on the page
- "See all notifications" link added to the header dropdown
- Filter tabs centered; styled to match the leaderboard period tabs

## Screenshots



<details>
  <summary><b>Screenshots</b> (Click to expand)</summary>

<img width="351" height="424" alt="image" src="https://github.com/user-attachments/assets/f008b6f2-20e9-4c3d-9dc7-e5071a3288ae" />

<img width="1607" height="1014" alt="image" src="https://github.com/user-attachments/assets/c6170f58-dab6-4612-a7c9-3d4665c08dfa" />
</details>

## Test plan
- [x] Open `/notifications` — all notifications load with infinite scroll
- [x] Switch filter tabs — list resets and fetches the correct type
- [x] Click a notification — marks it read, unread dot in header updates
- [x] "Mark all read" — clears all dots including the header badge
- [x] Header dropdown "See all notifications" link navigates to the page
- [x] No params to `/api/notifications` still returns 20 most recent (backward-compat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dedicated notifications page with infinite scrolling and pagination
  * Filter notifications by type (All, Follows, Kudos, Comments, Mentions)
  * Mark all notifications as read in bulk
  * "See all notifications" link in the header dropdown for quick access

* **Documentation**
  * Updated roadmap reflecting completion of notifications page with full feature details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
