### PR TITLE
feat: paste-to-upload images in post editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Paste-to-upload images in post editor.** Pasting an image from the clipboard (e.g. a screenshot) while the post editor is open now automatically uploads it — same compression pipeline and 10-image limit as the file picker. A "or paste from clipboard" hint appears next to the "Add images" button.
+
 - **Codex (OpenAI) usage tracking.** The CLI now reads `@ccusage/codex` data alongside Claude usage. Same-day Claude + Codex data is merged into a single post with summed tokens/costs. Feed cards show per-model cost percentages (e.g., "75% Claude Opus, 25% GPT-5") when `model_breakdown` data is available. Falls back to legacy highest-tier-model display for older rows. New `model_breakdown jsonb` column on `daily_usage`.
 - **Auto-generated post titles on sync.** When the CLI pushes usage, new posts get a title like "Feb 27 — Claude Opus, $4.82" from usage data. Existing posts aren't overwritten. Pending posts nudge now checks for missing description/images instead of missing title.
 - **CLI `?edit=1` deep links.** Post URLs printed after `npx straude@latest` now append `?edit=1`, opening the post editor on click.


### PR DESCRIPTION
## Summary

- Pasting an image from the clipboard (screenshot, copied image) while the post editor is open now automatically uploads it
- Uses the same compression pipeline and 10-image limit as the file picker
- Added a subtle "or paste from clipboard" hint next to the "Add images" button

## Screenshot

<img width="1012" height="334" alt="image" src="https://github.com/user-attachments/assets/1bb8dc7f-61c6-493e-a40a-5c19282331f0" />

## Test plan

- [x] Open a post you own and click "Edit post"
- [x] Take a screenshot, then paste (Cmd+V) anywhere in the editor — image should upload and appear as a thumbnail
- [x] Copy an image file from Finder and paste — same behaviour
- [x] Paste plain text — should work normally (no interference)
- [x] Verify the hint "or paste from clipboard" appears next to "Add images"
- [x] Verify pasting when already at 10 images does nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added clipboard paste functionality to the post editor. You can now paste images directly from your clipboard while composing a post—they'll be automatically uploaded using the same compression settings and 10-image limit as file-based uploads. A UI hint appears next to the upload button to guide users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->