### PR TITLE
fix: use service client for mention notification dedup to bypass RLS

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- **Mention notification duplicates on post edit.** The dedup query used the user-authenticated Supabase client, but RLS restricts notification reads to the owner. Switched to service client so the post author can see other users' existing notifications and skip re-inserting them.
 - **`after()` test failures.** Route handlers using Next.js `after()` for deferred work (notifications, achievements) threw outside a request scope in unit tests. Created `lib/utils/after.ts` shim so tests can mock it without loading the full `next/server` module. Added microtask flush to the mention-notification assertion.
 
 ### Simplify


### PR DESCRIPTION
The dedup query used the user-authenticated client, but RLS on notifications restricts reads to user_id = auth.uid(). The post author could never see other users' notifications, so the check always returned empty and duplicates were inserted on every edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention notification deduplication to properly prevent duplicate notifications when users are mentioned in posts.

* **Tests**
  * Updated test infrastructure to use centralized service mocks for improved consistency.

* **Documentation**
  * Updated changelog with mention notification handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->