### PR TITLE
fix: bun cache key and restore step ordering in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,17 @@ jobs:
         with:
           bun-version: latest
 
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install
         env:
           BUN_INSTALL_CACHE_DIR: ~/.bun/install/cache
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
 
       - name: Build
         run: bun run build


### PR DESCRIPTION
## Summary

- Fix cache key to use `bun.lock` instead of `bun.lockb` (correct lockfile name for this project)
- Move the `actions/cache` step before `bun install` so the cache is restored before dependencies are installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI/CD workflow configuration to optimize dependency caching and installation process order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->