### PR TITLE
Add bus-factor analysis script and report

### DIFF
--- a/docs/BUS_FACTOR_REPORT.md
+++ b/docs/BUS_FACTOR_REPORT.md
@@ -1,0 +1,88 @@
+# Bus Factor Report
+
+**Generated:** 2026-03-10
+**Repository:** straude
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Bus Factor | **1** |
+| Total Contributors | 2 |
+| Total Commits | 147 |
+| Files Tracked | 398 |
+| Files Analyzed (non-binary) | 398 |
+| Total Lines (blamed) | 54,435 |
+| Single-Author Files | 377 (94.7%) |
+
+## Line Ownership by Author
+
+| Author | Lines | Percentage |
+|--------|------:|-----------:|
+| Oscar Hong | 53,382 | 98.1% |
+| Alexey | 1,053 | 1.9% |
+
+## Commits by Author
+
+| Author | Commits |
+|--------|--------:|
+| Oscar Hong | 135 |
+| Alexey | 12 |
+
+## Directory-Level Bus Factor
+
+| Directory | Bus Factor | Lines | Top Author (%) |
+|-----------|:----------:|------:|----------------|
+| `apps` | 1 | 35,730 | Oscar Hong (97.3%) |
+| `.agents` | 1 | 5,702 | Oscar Hong (100.0%) |
+| `packages` | 1 | 4,366 | Oscar Hong (99.9%) |
+| `docs` | 1 | 3,483 | Oscar Hong (98.7%) |
+| `supabase` | 1 | 3,044 | Oscar Hong (98.3%) |
+| `gtm` | 1 | 970 | Oscar Hong (100.0%) |
+| `references` | 1 | 702 | Oscar Hong (100.0%) |
+| `(root)` | 1 | 277 | Oscar Hong (100.0%) |
+| `.claude` | 1 | 93 | Oscar Hong (100.0%) |
+| `.github` | 1 | 59 | Oscar Hong (100.0%) |
+| `.githooks` | 1 | 9 | Oscar Hong (100.0%) |
+
+## High-Risk Files (Single Author, 100+ Lines)
+
+| File | Lines | Author |
+|------|------:|--------|
+| `docs/straude-specs-v1.md` | 1,957 | Oscar Hong |
+| `gtm/JAPAN-LAUNCH.md` | 970 | Oscar Hong |
+| `.agents/skills/react-email/TESTS.md` | 878 | Oscar Hong |
+| `packages/cli/__tests__/commands/push.test.ts` | 817 | Oscar Hong |
+| `packages/cli/__tests__/flows/cli-sync-flow.test.ts` | 793 | Oscar Hong |
+| `apps/web/components/app/messages/MessagesInbox.tsx` | 783 | Oscar Hong |
+| `apps/web/__tests__/api/social.test.ts` | 758 | Oscar Hong |
+| `.agents/skills/react-email/references/PATTERNS.md` | 713 | Oscar Hong |
+| `apps/web/components/app/post/CommentThread.tsx` | 710 | Oscar Hong |
+| `references/Feed Mockup.html` | 702 | Oscar Hong |
+| `apps/web/__tests__/api/usage-submit.test.ts` | 684 | Oscar Hong |
+| `apps/web/lib/utils/share-image.tsx` | 674 | Oscar Hong |
+| `.agents/skills/react-email/references/I18N.md` | 657 | Oscar Hong |
+| `apps/web/app/(onboarding)/onboarding/page.tsx` | 569 | Oscar Hong |
+| `.agents/skills/react-email/SKILL.md` | 518 | Oscar Hong |
+| `apps/web/__tests__/flows/cli-push-flow.test.ts` | 504 | Oscar Hong |
+| `apps/web/lib/utils/recap-image.tsx` | 496 | Oscar Hong |
+| `apps/web/components/app/feed/ShareMenu.tsx` | 464 | Oscar Hong |
+| `apps/web/__tests__/api/messages.test.ts` | 435 | Oscar Hong |
+| `.agents/skills/react-email/references/COMPONENTS.md` | 429 | Oscar Hong |
+| `.agents/skills/email-best-practices/resources/transactional-email-catalog.md` | 418 | Oscar Hong |
+| `apps/web/__tests__/api/profile.test.ts` | 403 | Oscar Hong |
+| `apps/web/app/(app)/u/[username]/page.tsx` | 399 | Oscar Hong |
+| `apps/web/app/(app)/settings/page.tsx` | 393 | Oscar Hong |
+| `apps/web/scripts/generate-og-athletic-surge.ts` | 367 | Oscar Hong |
+| `apps/web/components/app/prompts/SubmitPromptWidget.tsx` | 362 | Oscar Hong |
+| `apps/web/scripts/generate-og-real-users.ts` | 347 | Oscar Hong |
+| `apps/web/app/(landing)/join/[username]/opengraph-image.tsx` | 332 | Oscar Hong |
+| `apps/web/app/api/messages/route.ts` | 319 | Oscar Hong |
+| `apps/web/__tests__/api/upload.test.ts` | 313 | Oscar Hong |
+
+## Recommendations
+
+- **Critical:** Bus factor is 1. The project depends entirely on a single contributor. Prioritize code review participation and pair programming to spread knowledge.
+- **High concentration:** 94.7% of files have a single author. Encourage contributions across the codebase.
+- **30 high-risk files** with 100+ lines and a single author. These are the highest-priority areas for knowledge sharing.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **Bus-factor analysis script and initial report.** Rerunnable `scripts/bus-factor.py` examines git blame and log data to quantify code ownership concentration. Generates per-file author counts, directory-level bus factor, line ownership percentages, and identifies high-risk single-owner areas. Initial snapshot saved to `docs/BUS_FACTOR_REPORT.md`.
 - **"Empty profile" nudge email for onboarded users who never pushed.** New email template, send function, and cron endpoint (`/api/cron/nudge-empty-profile`) targeting the 53 users who completed onboarding but have zero `daily_usage` rows. Supports dry-run mode (default) — append `?send=true` to actually send. Idempotency key `empty-profile/{userId}` prevents duplicates. Tagged `type: empty-profile` in Resend.
 - **Image and file attachments in DMs.** Users can now send images and files in direct messages. Images are compressed client-side (reusing the same `compressImage` utility from post uploads) and displayed inline with lightbox preview. Files (PDF, text, markdown, CSV, JSON, ZIP) render as download links with filename and size. Extracted `compressImage` to shared `lib/utils/compress-image.ts` for reuse across PostEditor and MessagesInbox. New `dm-attachments` storage bucket with 10MB limit. Messages can now be attachment-only (no text required). Thread previews show "Sent an attachment" for attachment-only messages.
 

--- a/scripts/bus-factor.py
+++ b/scripts/bus-factor.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Bus-Factor Analyzer for git repositories.
+
+Examines git log and blame data to quantify code ownership concentration
+across files and directories. Outputs per-file author counts, directory-level
+bus factor, line ownership percentages, and identifies high-risk single-owner areas.
+
+Usage:
+    python3 scripts/bus-factor.py [--repo-path PATH] [--markdown]
+
+Options:
+    --repo-path PATH   Path to the git repository (default: current directory)
+    --markdown         Output in Markdown format suitable for docs/BUS_FACTOR_REPORT.md
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+
+
+def run_git(args: list[str], cwd: str) -> str:
+    result = subprocess.run(
+        ["git"] + args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"git error: {result.stderr.strip()}", file=sys.stderr)
+        return ""
+    return result.stdout
+
+
+def get_tracked_files(cwd: str) -> list[str]:
+    """Get all tracked files in the repo (excludes binary/generated)."""
+    output = run_git(["ls-files"], cwd)
+    skip_patterns = (
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".svg",
+        ".woff", ".woff2", ".ttf", ".eot",
+        ".lock", ".map",
+        "node_modules/", ".next/", "dist/",
+    )
+    files = []
+    for f in output.strip().splitlines():
+        if not f:
+            continue
+        if any(f.endswith(p) or p in f for p in skip_patterns):
+            continue
+        files.append(f)
+    return files
+
+
+def get_blame_authors(filepath: str, cwd: str) -> Counter:
+    """Run git blame on a file and return a Counter of author -> line count."""
+    output = run_git(
+        ["blame", "--line-porcelain", "--", filepath],
+        cwd,
+    )
+    authors: Counter = Counter()
+    for line in output.splitlines():
+        if line.startswith("author "):
+            author = line[len("author "):]
+            authors[author] += 1
+    return authors
+
+
+def get_shortlog_authors(cwd: str) -> list[tuple[int, str]]:
+    """Get commit counts per author from git shortlog."""
+    output = run_git(["shortlog", "-sn", "--all", "--no-merges"], cwd)
+    results = []
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t", 1)
+        if len(parts) == 2:
+            results.append((int(parts[0].strip()), parts[1].strip()))
+    return results
+
+
+def compute_bus_factor(author_lines: Counter) -> int:
+    """
+    Bus factor = minimum number of authors whose combined contribution
+    exceeds 50% of total lines.
+    """
+    total = sum(author_lines.values())
+    if total == 0:
+        return 0
+    sorted_authors = author_lines.most_common()
+    cumulative = 0
+    for i, (_, count) in enumerate(sorted_authors, 1):
+        cumulative += count
+        if cumulative > total * 0.5:
+            return i
+    return len(sorted_authors)
+
+
+def analyze(cwd: str) -> dict:
+    """Run full bus-factor analysis and return structured results."""
+    files = get_tracked_files(cwd)
+    total_files = len(files)
+
+    # Per-file blame analysis
+    file_authors: dict[str, Counter] = {}
+    global_author_lines: Counter = Counter()
+    single_author_files = []
+    multi_author_files = []
+
+    for i, filepath in enumerate(files):
+        if (i + 1) % 50 == 0 or i == 0:
+            print(
+                f"  Analyzing file {i + 1}/{total_files}...",
+                file=sys.stderr,
+            )
+        authors = get_blame_authors(filepath, cwd)
+        if not authors:
+            continue
+        file_authors[filepath] = authors
+        global_author_lines += authors
+
+        if len(authors) == 1:
+            single_author_files.append(filepath)
+        else:
+            multi_author_files.append(filepath)
+
+    analyzed_files = len(file_authors)
+
+    # Directory-level aggregation
+    dir_authors: dict[str, Counter] = defaultdict(Counter)
+    for filepath, authors in file_authors.items():
+        parts = filepath.split("/")
+        # Top-level directory (or root for top-level files)
+        top_dir = parts[0] if len(parts) > 1 else "(root)"
+        dir_authors[top_dir] += authors
+
+    # Commit-level stats
+    shortlog = get_shortlog_authors(cwd)
+    total_commits = sum(c for c, _ in shortlog)
+
+    # Global bus factor
+    bus_factor = compute_bus_factor(global_author_lines)
+    total_lines = sum(global_author_lines.values())
+
+    # Per-directory bus factor
+    dir_bus_factors = {}
+    for d, authors in sorted(dir_authors.items()):
+        dir_bus_factors[d] = {
+            "bus_factor": compute_bus_factor(authors),
+            "total_lines": sum(authors.values()),
+            "authors": authors.most_common(),
+        }
+
+    # Author ownership percentages
+    author_percentages = []
+    for author, lines in global_author_lines.most_common():
+        author_percentages.append({
+            "author": author,
+            "lines": lines,
+            "percentage": round(lines / total_lines * 100, 1) if total_lines else 0,
+        })
+
+    # High-risk files (single author, >100 lines)
+    high_risk = []
+    for f in single_author_files:
+        total = sum(file_authors[f].values())
+        if total >= 100:
+            author = file_authors[f].most_common(1)[0][0]
+            high_risk.append({"file": f, "lines": total, "author": author})
+    high_risk.sort(key=lambda x: x["lines"], reverse=True)
+
+    return {
+        "date": str(date.today()),
+        "total_files_tracked": total_files,
+        "total_files_analyzed": analyzed_files,
+        "total_lines": total_lines,
+        "total_commits": total_commits,
+        "bus_factor": bus_factor,
+        "contributors": shortlog,
+        "single_author_files": len(single_author_files),
+        "single_author_pct": round(
+            len(single_author_files) / analyzed_files * 100, 1
+        ) if analyzed_files else 0,
+        "author_ownership": author_percentages,
+        "directory_breakdown": dir_bus_factors,
+        "high_risk_files": high_risk[:30],  # Top 30
+    }
+
+
+def format_markdown(data: dict) -> str:
+    """Format analysis results as a Markdown report."""
+    lines = []
+    lines.append(f"# Bus Factor Report")
+    lines.append("")
+    lines.append(f"**Generated:** {data['date']}")
+    lines.append(f"**Repository:** straude")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"| Metric | Value |")
+    lines.append(f"|--------|-------|")
+    lines.append(f"| Bus Factor | **{data['bus_factor']}** |")
+    lines.append(f"| Total Contributors | {len(data['contributors'])} |")
+    lines.append(f"| Total Commits | {data['total_commits']} |")
+    lines.append(f"| Files Tracked | {data['total_files_tracked']} |")
+    lines.append(f"| Files Analyzed (non-binary) | {data['total_files_analyzed']} |")
+    lines.append(f"| Total Lines (blamed) | {data['total_lines']:,} |")
+    lines.append(f"| Single-Author Files | {data['single_author_files']} ({data['single_author_pct']}%) |")
+    lines.append("")
+
+    lines.append("## Line Ownership by Author")
+    lines.append("")
+    lines.append("| Author | Lines | Percentage |")
+    lines.append("|--------|------:|-----------:|")
+    for entry in data["author_ownership"]:
+        lines.append(
+            f"| {entry['author']} | {entry['lines']:,} | {entry['percentage']}% |"
+        )
+    lines.append("")
+
+    lines.append("## Commits by Author")
+    lines.append("")
+    lines.append("| Author | Commits |")
+    lines.append("|--------|--------:|")
+    for commits, author in data["contributors"]:
+        lines.append(f"| {author} | {commits} |")
+    lines.append("")
+
+    lines.append("## Directory-Level Bus Factor")
+    lines.append("")
+    lines.append("| Directory | Bus Factor | Lines | Top Author (%) |")
+    lines.append("|-----------|:----------:|------:|----------------|")
+    for d, info in sorted(
+        data["directory_breakdown"].items(),
+        key=lambda x: x[1]["total_lines"],
+        reverse=True,
+    ):
+        top_author, top_count = info["authors"][0] if info["authors"] else ("N/A", 0)
+        top_pct = round(top_count / info["total_lines"] * 100, 1) if info["total_lines"] else 0
+        lines.append(
+            f"| `{d}` | {info['bus_factor']} | {info['total_lines']:,} | {top_author} ({top_pct}%) |"
+        )
+    lines.append("")
+
+    lines.append("## High-Risk Files (Single Author, 100+ Lines)")
+    lines.append("")
+    if data["high_risk_files"]:
+        lines.append("| File | Lines | Author |")
+        lines.append("|------|------:|--------|")
+        for entry in data["high_risk_files"]:
+            lines.append(
+                f"| `{entry['file']}` | {entry['lines']:,} | {entry['author']} |"
+            )
+    else:
+        lines.append("No high-risk single-author files found.")
+    lines.append("")
+
+    lines.append("## Recommendations")
+    lines.append("")
+    if data["bus_factor"] <= 1:
+        lines.append(
+            "- **Critical:** Bus factor is 1. The project depends entirely on a single contributor. "
+            "Prioritize code review participation and pair programming to spread knowledge."
+        )
+    if data["single_author_pct"] > 80:
+        lines.append(
+            f"- **High concentration:** {data['single_author_pct']}% of files have a single author. "
+            "Encourage contributions across the codebase."
+        )
+    if data["high_risk_files"]:
+        lines.append(
+            f"- **{len(data['high_risk_files'])} high-risk files** with 100+ lines and a single author. "
+            "These are the highest-priority areas for knowledge sharing."
+        )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_text(data: dict) -> str:
+    """Format analysis results as plain text."""
+    lines = []
+    lines.append(f"Bus Factor Analysis — {data['date']}")
+    lines.append("=" * 50)
+    lines.append(f"Bus Factor:           {data['bus_factor']}")
+    lines.append(f"Contributors:         {len(data['contributors'])}")
+    lines.append(f"Total Commits:        {data['total_commits']}")
+    lines.append(f"Files Analyzed:       {data['total_files_analyzed']}")
+    lines.append(f"Total Lines:          {data['total_lines']:,}")
+    lines.append(
+        f"Single-Author Files:  {data['single_author_files']} ({data['single_author_pct']}%)"
+    )
+    lines.append("")
+    lines.append("Line Ownership:")
+    for entry in data["author_ownership"]:
+        lines.append(
+            f"  {entry['author']:<30} {entry['lines']:>8,} lines ({entry['percentage']}%)"
+        )
+    lines.append("")
+    lines.append("Directory Bus Factors:")
+    for d, info in sorted(
+        data["directory_breakdown"].items(),
+        key=lambda x: x[1]["total_lines"],
+        reverse=True,
+    ):
+        lines.append(f"  {d:<20} BF={info['bus_factor']}  ({info['total_lines']:,} lines)")
+    lines.append("")
+    lines.append(f"High-Risk Files (single author, 100+ lines): {len(data['high_risk_files'])}")
+    for entry in data["high_risk_files"][:10]:
+        lines.append(f"  {entry['file']:<60} {entry['lines']:>5} lines  ({entry['author']})")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze git repository bus factor")
+    parser.add_argument(
+        "--repo-path",
+        default=".",
+        help="Path to the git repository (default: current directory)",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Output in Markdown format",
+    )
+    args = parser.parse_args()
+
+    cwd = os.path.abspath(args.repo_path)
+    if not os.path.isdir(os.path.join(cwd, ".git")):
+        print(f"Error: {cwd} is not a git repository", file=sys.stderr)
+        sys.exit(1)
+
+    print("Running bus-factor analysis...", file=sys.stderr)
+    data = analyze(cwd)
+
+    if args.markdown:
+        print(format_markdown(data))
+    else:
+        print(format_text(data))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Added `scripts/bus-factor.py` — a rerunnable Python script that examines git blame and log data to quantify code ownership concentration
- Generated initial snapshot report at `docs/BUS_FACTOR_REPORT.md` (2026-03-10)
- Updated CHANGELOG.md

### Key findings
| Metric | Value |
|--------|-------|
| Bus Factor | **1** |
| Contributors | 2 |
| Single-Author Files | 377 / 398 (94.7%) |
| Top Author (Oscar Hong) | 98.1% of lines, 135 / 147 commits |
| High-Risk Files (100+ lines, single author) | 30 |

Every directory has a bus factor of 1. The `apps/` directory (35,730 lines) is 97.3% Oscar Hong.

## Test plan
- [ ] Verify `python3 scripts/bus-factor.py` runs cleanly from repo root
- [ ] Verify `python3 scripts/bus-factor.py --markdown` produces valid Markdown
- [ ] Review `docs/BUS_FACTOR_REPORT.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: bus-factor:/Users/ohong/dev/straude
task-type: bus-factor
task-title: Bus-Factor Analyzer
iterations: 1
duration: 4m41s
nightshift:metadata -->
