### PR TITLE
chore: remove runtime explicit-any usage

### DIFF
--- a/apps/web/__tests__/flows/leaderboard-ranking.test.ts
+++ b/apps/web/__tests__/flows/leaderboard-ranking.test.ts
@@ -9,8 +9,16 @@ const mockSupabase = {
   rpc: vi.fn().mockResolvedValue({ data: [] }),
 };
 
+const mockServiceClient = {
+  from: vi.fn(),
+};
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(() => mockSupabase),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  getServiceClient: vi.fn(() => mockServiceClient),
 }));
 
 // ---------------------------------------------------------------------------
@@ -23,7 +31,10 @@ vi.mock("@/lib/supabase/server", () => ({
  */
 function chainBuilder(resolvedData: Record<string, unknown> = { data: [], error: null }) {
   let _resolved = resolvedData;
-  const chain: Record<string, any> = {};
+  const chain: Record<string, ReturnType<typeof vi.fn>> & {
+    then?: (resolve: (value: Record<string, unknown>) => unknown, reject?: (error: unknown) => unknown) => Promise<unknown>;
+    _setResolved?: (value: Record<string, unknown>) => void;
+  } = {};
   const methods = [
     "select", "insert", "update", "upsert", "delete",
     "eq", "neq", "gt", "lt", "gte", "lte", "in", "is",
@@ -35,7 +46,7 @@ function chainBuilder(resolvedData: Record<string, unknown> = { data: [], error:
   chain.single = vi.fn(() => Promise.resolve(_resolved));
   chain.maybeSingle = vi.fn(() => Promise.resolve(_resolved));
   // Make chain thenable — `await chain` resolves to _resolved
-  chain.then = (resolve: any, reject: any) => Promise.resolve(_resolved).then(resolve, reject);
+  chain.then = (resolve, reject) => Promise.resolve(_resolved).then(resolve, reject);
   // Allow tests to change the resolution value
   chain._setResolved = (val: Record<string, unknown>) => { _resolved = val; };
   return chain;
@@ -56,6 +67,7 @@ describe("Flow: Leaderboard Ranking", () => {
     vi.clearAllMocks();
     vi.resetModules();
     mockSupabase.rpc.mockResolvedValue({ data: [] });
+    mockServiceClient.from.mockReset();
   });
 
   it("returns users sorted by cost DESC with correct rank badges", async () => {
@@ -74,10 +86,13 @@ describe("Flow: Leaderboard Ranking", () => {
     const lbChain = chainBuilder({ data: entries, error: null });
 
     mockSupabase.from.mockImplementation(() => lbChain);
+    mockServiceClient.from.mockImplementation(() =>
+      chainBuilder({ data: [], error: null })
+    );
 
     const { GET } = await import("@/app/api/leaderboard/route");
     const req = makeRequest("http://localhost:3000/api/leaderboard?period=week");
-    const res = await GET(req as any);
+    const res = await GET(req as Request & { nextUrl: URL });
     const data = await res.json();
 
     expect(res.status).toBe(200);
@@ -104,15 +119,18 @@ describe("Flow: Leaderboard Ranking", () => {
     const lbChain = chainBuilder({ data: naEntries, error: null });
 
     mockSupabase.from.mockImplementation(() => lbChain);
+    mockServiceClient.from.mockImplementation(() =>
+      chainBuilder({ data: [], error: null })
+    );
 
     const { GET } = await import("@/app/api/leaderboard/route");
     const req = makeRequest("http://localhost:3000/api/leaderboard?period=week&region=north_america");
-    const res = await GET(req as any);
+    const res = await GET(req as Request & { nextUrl: URL });
     const data = await res.json();
 
     expect(res.status).toBe(200);
     expect(data.entries).toHaveLength(2);
-    expect(data.entries.every((e: any) => e.region === "north_america")).toBe(true);
+    expect(data.entries.every((entry: { region: string }) => entry.region === "north_america")).toBe(true);
     expect(lbChain.eq).toHaveBeenCalledWith("region", "north_america");
   });
 
@@ -123,6 +141,9 @@ describe("Flow: Leaderboard Ranking", () => {
 
     const lbChain = chainBuilder({ data: [], error: null });
     mockSupabase.from.mockImplementation(() => lbChain);
+    mockServiceClient.from.mockImplementation(() =>
+      chainBuilder({ data: [], error: null })
+    );
 
     const { GET } = await import("@/app/api/leaderboard/route");
 
@@ -136,7 +157,7 @@ describe("Flow: Leaderboard Ranking", () => {
       mockSupabase.from.mockImplementation(() => lbChain);
 
       const req = makeRequest(`http://localhost:3000/api/leaderboard?period=${period}`);
-      await GET(req as any);
+      await GET(req as Request & { nextUrl: URL });
 
       expect(mockSupabase.from).toHaveBeenCalledWith(view);
     }
@@ -149,7 +170,7 @@ describe("Flow: Leaderboard Ranking", () => {
 
     const { GET } = await import("@/app/api/leaderboard/route");
     const req = makeRequest("http://localhost:3000/api/leaderboard?period=invalid");
-    const res = await GET(req as any);
+    const res = await GET(req as Request & { nextUrl: URL });
 
     expect(res.status).toBe(400);
   });
@@ -184,10 +205,13 @@ describe("Flow: Leaderboard Ranking", () => {
       // count above
       return chainBuilder(countResult);
     });
+    mockServiceClient.from.mockImplementation(() =>
+      chainBuilder({ data: [], error: null })
+    );
 
     const { GET } = await import("@/app/api/leaderboard/route");
     const req = makeRequest("http://localhost:3000/api/leaderboard?period=week");
-    const res = await GET(req as any);
+    const res = await GET(req as Request & { nextUrl: URL });
     const data = await res.json();
 
     expect(res.status).toBe(200);

--- a/apps/web/app/(app)/feed/page.tsx
+++ b/apps/web/app/(app)/feed/page.tsx
@@ -1,7 +1,15 @@
 import { createClient } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/supabase/auth";
 import { FeedList } from "@/components/app/feed/FeedList";
+import { normalizeCommentPreview, normalizeFeedPost, type JoinedUserSummary, type RawCommentPreviewRow } from "@/lib/feed-normalization";
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { CommentPreviewItem, FeedPostRow, Post, UserSummary } from "@/types";
 import type { Metadata } from "next";
+
+type KudosRow = {
+  post_id: string;
+  user: JoinedUserSummary;
+};
 
 const FEED_DESCRIPTION =
   "See the latest Claude Code sessions from the Straude community.";
@@ -57,11 +65,11 @@ export default async function FeedPage({
     p_user_id: user?.id ?? null,
     p_limit: 20,
   });
-  let posts: any[] = data ?? [];
+  let posts: Post[] = ((data ?? []) as FeedPostRow[]).map(normalizeFeedPost);
 
   // Fetch incomplete posts for the logged-in user (bare synced sessions).
   // Show nudge on all tabs so the user is reminded regardless of which feed they view.
-  let pendingPosts: any[] = [];
+  let pendingPosts: Post[] = [];
   if (user) {
     const { data } = await supabase
       .from("posts")
@@ -71,12 +79,12 @@ export default async function FeedPage({
       .eq("images", "[]")
       .order("created_at", { ascending: false })
       .limit(5);
-    pendingPosts = data ?? [];
+    pendingPosts = ((data ?? []) as FeedPostRow[]).map(normalizeFeedPost);
   }
 
   // Enrich with kudos status + kudos users + recent comments
   if (posts.length > 0) {
-    const postIds = posts.map((p: any) => p.id);
+    const postIds = posts.map((post) => post.id);
 
     // User-specific kudos check only when logged in
     const userKudosPromise = user
@@ -107,34 +115,33 @@ export default async function FeedPage({
 
     const kudosedSet = new Set((userKudos ?? []).map((k) => k.post_id));
 
-    const kudosUsersMap = new Map<string, any[]>();
-    for (const k of recentKudos ?? []) {
-      const list = kudosUsersMap.get(k.post_id) ?? [];
-      if (list.length < 3) {
-        list.push(k.user);
-        kudosUsersMap.set(k.post_id, list);
+    const kudosUsersMap = new Map<string, UserSummary[]>();
+    for (const kudos of (recentKudos ?? []) as KudosRow[]) {
+      const list = kudosUsersMap.get(kudos.post_id) ?? [];
+      const userSummary = firstRelation(kudos.user);
+      if (list.length < 3 && userSummary) {
+        list.push(userSummary);
+        kudosUsersMap.set(kudos.post_id, list);
       }
     }
 
-    const commentsMap = new Map<string, any[]>();
-    for (const c of recentComments ?? []) {
-      const list = commentsMap.get(c.post_id) ?? [];
+    const commentsMap = new Map<string, CommentPreviewItem[]>();
+    for (const comment of (recentComments ?? []) as RawCommentPreviewRow[]) {
+      const list = commentsMap.get(comment.post_id) ?? [];
       if (list.length < 2) {
-        list.push(c);
-        commentsMap.set(c.post_id, list);
+        list.push(normalizeCommentPreview(comment));
+        commentsMap.set(comment.post_id, list);
       }
     }
     for (const [, list] of commentsMap) {
       list.reverse();
     }
 
-    posts = posts.map((p: any) => ({
-      ...p,
-      kudos_count: typeof p.kudos_count === "number" ? p.kudos_count : p.kudos_count?.[0]?.count ?? 0,
-      kudos_users: kudosUsersMap.get(p.id) ?? [],
-      comment_count: typeof p.comment_count === "number" ? p.comment_count : p.comment_count?.[0]?.count ?? 0,
-      recent_comments: commentsMap.get(p.id) ?? [],
-      has_kudosed: kudosedSet.has(p.id),
+    posts = posts.map((post) => ({
+      ...post,
+      kudos_users: kudosUsersMap.get(post.id) ?? [],
+      recent_comments: commentsMap.get(post.id) ?? [],
+      has_kudosed: kudosedSet.has(post.id),
     }));
   }
 

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -9,9 +9,17 @@ import { MobileNav } from "@/components/app/shared/MobileNav";
 import { GuestHeader, GuestMobileNav } from "@/components/app/shared/GuestHeader";
 import { CommandPalette } from "@/components/app/shared/CommandPalette";
 import { SubmitPromptWidget } from "@/components/app/prompts/SubmitPromptWidget";
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { DailyUsage } from "@/types";
 
 // Pages that are publicly accessible without login
 const PUBLIC_PAGES = ["/feed", "/leaderboard"];
+type LatestPostRow = {
+  id: string;
+  title: string | null;
+  created_at: string;
+  daily_usage: Array<Pick<DailyUsage, "date">> | null;
+};
 
 export default async function AppLayout({
   children,
@@ -101,10 +109,10 @@ export default async function AppLayout({
   const totalCost =
     allTimeUsageRes.data?.reduce((s, r) => s + Number(r.cost_usd), 0) ?? 0;
 
-  const latestPosts = (latestPostRes.data ?? [])
+  const latestPosts = ((latestPostRes.data ?? []) as LatestPostRow[])
     .map((row) => {
       // Prefer the usage date (user's local date) over created_at (UTC timestamp)
-      const usageDate = (row.daily_usage as any)?.date as string | undefined;
+      const usageDate = firstRelation(row.daily_usage)?.date;
       const sortKey = usageDate ?? row.created_at;
       const displayDate = usageDate
         ? new Date(usageDate + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })

--- a/apps/web/app/(app)/leaderboard/page.tsx
+++ b/apps/web/app/(app)/leaderboard/page.tsx
@@ -2,7 +2,14 @@ import { createClient } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/supabase/auth";
 import { getServiceClient } from "@/lib/supabase/service";
 import { LeaderboardTable } from "@/components/app/leaderboard/LeaderboardTable";
+import type { LeaderboardEntry } from "@/types";
 import type { Metadata } from "next";
+
+type LeaderboardViewRow = Omit<LeaderboardEntry, "rank" | "streak"> & {
+  display_name: string | null;
+  total_cost: number | string;
+  total_output_tokens: number | string;
+};
 
 const LEADERBOARD_DESCRIPTION =
   "See who's leading the pack. Weekly, monthly, and all-time Claude Code spend rankings.";
@@ -57,10 +64,11 @@ export default async function LeaderboardPage({
   if (region) {
     query = query.eq("region", region);
   }
-  const { data: entries } = await query;
+  const { data: rawEntries } = await query;
+  const entries = (rawEntries ?? []) as LeaderboardViewRow[];
 
   // Fetch streaks for all leaderboard users in a single RPC call
-  const userIds = (entries ?? []).map((e: any) => e.user_id);
+  const userIds = entries.map((entry) => entry.user_id);
   const { data: streakRows } = userIds.length > 0
     ? await supabase.rpc("calculate_streaks_batch", { p_user_ids: userIds })
     : { data: [] };
@@ -83,15 +91,14 @@ export default async function LeaderboardPage({
   }
 
   // Add rank numbers and streaks
-  const ranked =
-    entries?.map((e: any, i: number) => ({
-      ...e,
+  const ranked: LeaderboardEntry[] = entries.map((entry, i) => ({
+      ...entry,
       rank: i + 1,
-      total_cost: Number(e.total_cost),
-      total_output_tokens: Number(e.total_output_tokens),
-      streak: streakMap.get(e.user_id) ?? 0,
-      level: levelMap.get(e.user_id),
-    })) ?? [];
+      total_cost: Number(entry.total_cost),
+      total_output_tokens: Number(entry.total_output_tokens),
+      streak: streakMap.get(entry.user_id) ?? 0,
+      level: levelMap.get(entry.user_id),
+    }));
 
   return (
     <>

--- a/apps/web/app/(app)/post/[id]/page.tsx
+++ b/apps/web/app/(app)/post/[id]/page.tsx
@@ -4,7 +4,18 @@ import { ActivityCard } from "@/components/app/feed/ActivityCard";
 import { CommentThread } from "@/components/app/post/CommentThread";
 import { PostEditor } from "@/components/app/post/PostEditor";
 import { loadPostComments } from "@/lib/comments";
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { AggregateCount, FeedPostRow, UserSummary } from "@/types";
 import type { Metadata } from "next";
+
+type MetadataPostRow = {
+  title: string | null;
+  user: Array<{ username: string | null }> | null;
+};
+
+type RecentKudosRow = {
+  user: Array<UserSummary> | null;
+};
 
 export async function generateMetadata({
   params,
@@ -13,14 +24,15 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { id } = await params;
   const supabase = await createClient();
-  const { data: post } = await supabase
+  const { data: rawPost } = await supabase
     .from("posts")
     .select("title, user:users!posts_user_id_fkey(username)")
     .eq("id", id)
     .single();
+  const post = rawPost as MetadataPostRow | null;
 
   return {
-    title: post?.title ?? `Post by ${(post?.user as any)?.username ?? "user"}`,
+    title: post?.title ?? `Post by ${firstRelation(post?.user)?.username ?? "user"}`,
   };
 }
 
@@ -100,11 +112,12 @@ export default async function PostDetailPage({
 
   const hasKudosed = !!kudosCheck;
 
+  const postRow = post as FeedPostRow;
   const normalizedPost = {
-    ...post,
-    kudos_count: (post.kudos_count as any)?.[0]?.count ?? 0,
-    kudos_users: (recentKudos ?? []).map((k) => k.user as any),
-    comment_count: (post.comment_count as any)?.[0]?.count ?? 0,
+    ...postRow,
+    kudos_count: ((postRow.kudos_count as AggregateCount[] | undefined)?.[0]?.count ?? 0),
+    kudos_users: (recentKudos ?? []).map((k) => firstRelation((k as RecentKudosRow).user)).filter((user): user is UserSummary => Boolean(user)),
+    comment_count: ((postRow.comment_count as AggregateCount[] | undefined)?.[0]?.count ?? 0),
     has_kudosed: hasKudosed,
   };
 

--- a/apps/web/app/(app)/post/new/page.tsx
+++ b/apps/web/app/(app)/post/new/page.tsx
@@ -1,7 +1,15 @@
 import { createClient } from "@/lib/supabase/server";
 import Link from "next/link";
 import type { Metadata } from "next";
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { DailyUsage } from "@/types";
 import { CopyCommand } from "./CopyCommand";
+
+type UneditedPostRow = {
+  id: string;
+  created_at: string;
+  daily_usage: Array<Pick<DailyUsage, "date" | "cost_usd" | "models">> | null;
+};
 
 export const metadata: Metadata = { title: "Upload Activity" };
 
@@ -28,7 +36,7 @@ export default async function NewPostPage() {
     .order("created_at", { ascending: false })
     .limit(10);
 
-  const unedited = posts ?? [];
+  const unedited = (posts ?? []) as UneditedPostRow[];
 
   return (
     <>
@@ -44,8 +52,8 @@ export default async function NewPostPage() {
               Your recent posts
             </h4>
             <ul className="mt-3 divide-y divide-border rounded border border-border">
-              {unedited.map((post: any) => {
-                const usage = post.daily_usage;
+              {unedited.map((post) => {
+                const usage = firstRelation(post.daily_usage);
                 return (
                   <li key={post.id}>
                     <Link

--- a/apps/web/app/(app)/prompts/page.tsx
+++ b/apps/web/app/(app)/prompts/page.tsx
@@ -2,7 +2,13 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
+import { firstRelation } from "@/lib/utils/first-relation";
 import { timeAgo } from "@/lib/utils/format";
+import type { PromptSubmission } from "@/types";
+
+type PromptListRow = Pick<PromptSubmission, "id" | "prompt" | "is_anonymous" | "created_at" | "status"> & {
+  user: Array<{ username: string | null }> | null;
+};
 
 export const metadata: Metadata = { title: "Prompts" };
 
@@ -30,7 +36,7 @@ export default async function PromptsPage() {
     throw new Error(error.message);
   }
 
-  const prompts = data ?? [];
+  const prompts = (data ?? []) as PromptListRow[];
 
   return (
     <>
@@ -47,8 +53,8 @@ export default async function PromptsPage() {
         </p>
       ) : (
         <div className="divide-y divide-border">
-          {prompts.map((row: any) => {
-            const username = row.user?.username as string | null | undefined;
+          {prompts.map((row) => {
+            const username = firstRelation(row.user)?.username;
             const isAnonymous = Boolean(row.is_anonymous);
             return (
               <article key={row.id} className="px-4 py-5 sm:px-6">

--- a/apps/web/app/(app)/search/page.tsx
+++ b/apps/web/app/(app)/search/page.tsx
@@ -68,18 +68,8 @@ function SearchContent() {
           </p>
         )}
         {results.map((user) => {
-          const hasProfile = !!user.username;
-          const Wrapper = hasProfile ? Link : "div";
-          const wrapperProps = hasProfile
-            ? { href: `/u/${user.username}` }
-            : {};
-
-          return (
-            <Wrapper
-              key={user.id}
-              {...(wrapperProps as any)}
-              className="flex items-center gap-4 border-b border-border px-6 py-4 hover:bg-subtle"
-            >
+          const content = (
+            <>
               <Avatar
                 src={user.avatar_url}
                 alt={user.username ?? user.display_name ?? ""}
@@ -102,7 +92,24 @@ function SearchContent() {
                   </p>
                 )}
               </div>
-            </Wrapper>
+            </>
+          );
+
+          return user.username ? (
+            <Link
+              key={user.id}
+              href={`/u/${user.username}`}
+              className="flex items-center gap-4 border-b border-border px-6 py-4 hover:bg-subtle"
+            >
+              {content}
+            </Link>
+          ) : (
+            <div
+              key={user.id}
+              className="flex items-center gap-4 border-b border-border px-6 py-4"
+            >
+              {content}
+            </div>
           );
         })}
       </div>

--- a/apps/web/app/(app)/u/[username]/follows/page.tsx
+++ b/apps/web/app/(app)/u/[username]/follows/page.tsx
@@ -2,6 +2,7 @@ import { getServiceClient } from "@/lib/supabase/service";
 import { getProfileAccessContext } from "@/lib/profile-access";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { firstRelation } from "@/lib/utils/first-relation";
 import { Avatar } from "@/components/ui/Avatar";
 import type { Metadata } from "next";
 
@@ -10,6 +11,15 @@ type FollowsProfileRow = {
   username: string | null;
   is_public: boolean;
 };
+type FollowUserRow = {
+  id: string;
+  username: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+};
+type FollowingRelationRow = { following: FollowUserRow[] | null };
+type FollowerRelationRow = { follower: FollowUserRow[] | null };
 
 export async function generateMetadata({
   params,
@@ -53,7 +63,9 @@ export default async function FollowsPage({
       .eq("follower_id", profile.id)
       .order("created_at", { ascending: false });
 
-    users = (data ?? []).map((r: any) => r.following).filter(Boolean);
+    users = ((data ?? []) as FollowingRelationRow[])
+      .map((row) => firstRelation(row.following))
+      .filter((user): user is FollowUserRow => Boolean(user));
   } else {
     const { data } = await db
       .from("follows")
@@ -61,7 +73,9 @@ export default async function FollowsPage({
       .eq("following_id", profile.id)
       .order("created_at", { ascending: false });
 
-    users = (data ?? []).map((r: any) => r.follower).filter(Boolean);
+    users = ((data ?? []) as FollowerRelationRow[])
+      .map((row) => firstRelation(row.follower))
+      .filter((user): user is FollowUserRow => Boolean(user));
   }
 
   return (

--- a/apps/web/app/(app)/u/[username]/page.tsx
+++ b/apps/web/app/(app)/u/[username]/page.tsx
@@ -12,7 +12,19 @@ import { FeedList } from "@/components/app/feed/FeedList";
 import { FollowButton } from "@/components/app/profile/FollowButton";
 import { InviteButton } from "@/components/app/profile/InviteButton";
 import { formatTokens } from "@/lib/utils/format";
+import { normalizeCommentPreview, type JoinedUserSummary, type RawCommentPreviewRow } from "@/lib/feed-normalization";
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { CommentPreviewItem, FeedPostRow, Post, UserSummary } from "@/types";
 import type { Metadata } from "next";
+
+type PostDateRow = {
+  daily_usage: Array<{ date: string }> | null;
+};
+
+type KudosRow = {
+  post_id: string;
+  user: JoinedUserSummary;
+};
 
 type ProfileRow = {
   id: string;
@@ -158,7 +170,9 @@ export default async function ProfilePage({
     .eq("user_id", profile.id);
 
   const postDateSet = new Set(
-    postDates?.map((p: any) => p.daily_usage?.date).filter(Boolean)
+    ((postDates ?? []) as PostDateRow[])
+      .map((post) => firstRelation(post.daily_usage)?.date)
+      .filter((date): date is string => Boolean(date))
   );
 
   const contributionData = (contributions ?? []).map((c) => ({
@@ -174,9 +188,10 @@ export default async function ProfilePage({
     p_limit: 20,
   });
 
-  let normalizedPosts: any[] = [];
+  let normalizedPosts: Post[] = [];
   if (posts && posts.length > 0) {
-    const postIds = posts.map((p: any) => p.id);
+    const feedPosts = posts as FeedPostRow[];
+    const postIds = feedPosts.map((post) => post.id);
 
     const [{ data: userKudos }, { data: recentKudos }, { data: recentComments }] =
       await Promise.all([
@@ -186,7 +201,7 @@ export default async function ProfilePage({
               .select("post_id")
               .eq("user_id", authUserId)
               .in("post_id", postIds)
-          : Promise.resolve({ data: [] as any[] }),
+          : Promise.resolve({ data: [] as { post_id: string }[] }),
         db
           .from("kudos")
           .select("post_id, user:users!kudos_user_id_fkey(avatar_url, username)")
@@ -204,34 +219,35 @@ export default async function ProfilePage({
 
     const kudosedSet = new Set(userKudos?.map((k) => k.post_id));
 
-    const kudosUsersMap = new Map<string, any[]>();
-    for (const k of recentKudos ?? []) {
-      const list = kudosUsersMap.get(k.post_id) ?? [];
-      if (list.length < 3) {
-        list.push(k.user);
-        kudosUsersMap.set(k.post_id, list);
+    const kudosUsersMap = new Map<string, UserSummary[]>();
+    for (const kudos of (recentKudos ?? []) as KudosRow[]) {
+      const list = kudosUsersMap.get(kudos.post_id) ?? [];
+      const userSummary = firstRelation(kudos.user);
+      if (list.length < 3 && userSummary) {
+        list.push(userSummary);
+        kudosUsersMap.set(kudos.post_id, list);
       }
     }
 
-    const commentsMap = new Map<string, any[]>();
-    for (const c of recentComments ?? []) {
-      const list = commentsMap.get(c.post_id) ?? [];
+    const commentsMap = new Map<string, CommentPreviewItem[]>();
+    for (const comment of (recentComments ?? []) as RawCommentPreviewRow[]) {
+      const list = commentsMap.get(comment.post_id) ?? [];
       if (list.length < 2) {
-        list.push(c);
-        commentsMap.set(c.post_id, list);
+        list.push(normalizeCommentPreview(comment));
+        commentsMap.set(comment.post_id, list);
       }
     }
     for (const [, list] of commentsMap) {
       list.reverse();
     }
 
-    normalizedPosts = posts.map((p: any) => ({
-      ...p,
-      kudos_count: typeof p.kudos_count === "number" ? p.kudos_count : p.kudos_count?.[0]?.count ?? 0,
-      kudos_users: kudosUsersMap.get(p.id) ?? [],
-      comment_count: typeof p.comment_count === "number" ? p.comment_count : p.comment_count?.[0]?.count ?? 0,
-      recent_comments: commentsMap.get(p.id) ?? [],
-      has_kudosed: kudosedSet.has(p.id),
+    normalizedPosts = feedPosts.map((post) => ({
+      ...post,
+      kudos_count: typeof post.kudos_count === "number" ? post.kudos_count : post.kudos_count?.[0]?.count ?? 0,
+      kudos_users: kudosUsersMap.get(post.id) ?? [],
+      comment_count: typeof post.comment_count === "number" ? post.comment_count : post.comment_count?.[0]?.count ?? 0,
+      recent_comments: commentsMap.get(post.id) ?? [],
+      has_kudosed: kudosedSet.has(post.id),
     }));
   }
 

--- a/apps/web/app/admin/components/CodexGrowthCharts.tsx
+++ b/apps/web/app/admin/components/CodexGrowthCharts.tsx
@@ -133,7 +133,7 @@ function ChartCard({
   );
 }
 
-function filterByRange(data: any[], range: string) {
+function filterByRange<T>(data: T[], range: string) {
   const r = RANGES.find((r) => r.key === range);
   if (!r || r.days === Infinity) return data;
   return data.slice(-r.days);

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { isAdmin } from "@/lib/admin";
 import { getServiceClient } from "@/lib/supabase/service";
+import { firstRelation } from "@/lib/utils/first-relation";
 import { StatCard } from "./components/StatCard";
 import { NorthStarChart } from "./components/NorthStarChart";
 import { TopUsersTable } from "./components/TopUsersTable";
@@ -13,6 +14,39 @@ import { CodexGrowthCharts } from "./components/CodexGrowthCharts";
 import { RevenueConcentration } from "./components/RevenueConcentration";
 import { TimeToFirstSync } from "./components/TimeToFirstSync";
 import { PromptInbox } from "./components/PromptInbox";
+
+type SpendRow = {
+  date: string;
+  daily_total: number | string;
+  cumulative_total: number | string;
+};
+type TopUserRow = {
+  total_spend: number | string;
+  total_tokens: number | string;
+  usage_days: number | string;
+} & Record<string, unknown>;
+type FunnelRow = { stage: string; count: number | string };
+type GrowthRow = { date: string; signups: number | string; cumulative_users: number | string };
+type DailyUsageUserRow = { user_id: string };
+type PromptInboxRow = {
+  id: string;
+  prompt: string;
+  is_anonymous: boolean;
+  status: "new" | "accepted" | "in_progress" | "rejected" | "shipped";
+  is_hidden: boolean;
+  created_at: string;
+  user: Array<{ username: string | null; display_name: string | null }> | null;
+};
+type TopUsersTableRow = {
+  user_id: string;
+  username: string;
+  avatar_url: string | null;
+  total_spend: number;
+  total_tokens: number;
+  usage_days: number;
+  last_active: string;
+  signed_up: string;
+};
 
 export default async function AdminPage() {
   const authClient = await createClient();
@@ -50,28 +84,28 @@ export default async function AdminPage() {
       .limit(200),
   ]);
 
-  const spendData = (spendRes.data ?? []).map((r: any) => ({
-    date: r.date,
-    daily_total: Number(r.daily_total),
-    cumulative_total: Number(r.cumulative_total),
+  const spendData = ((spendRes.data ?? []) as SpendRow[]).map((row) => ({
+    date: row.date,
+    daily_total: Number(row.daily_total),
+    cumulative_total: Number(row.cumulative_total),
   }));
 
-  const topUsers = (usersRes.data ?? []).map((r: any) => ({
-    ...r,
-    total_spend: Number(r.total_spend),
-    total_tokens: Number(r.total_tokens),
-    usage_days: Number(r.usage_days),
+  const topUsers: TopUsersTableRow[] = ((usersRes.data ?? []) as TopUserRow[]).map((row) => ({
+    ...row,
+    total_spend: Number(row.total_spend),
+    total_tokens: Number(row.total_tokens),
+    usage_days: Number(row.usage_days),
+  })) as TopUsersTableRow[];
+
+  const funnelData = ((funnelRes.data ?? []) as FunnelRow[]).map((row) => ({
+    stage: row.stage,
+    count: Number(row.count),
   }));
 
-  const funnelData = (funnelRes.data ?? []).map((r: any) => ({
-    stage: r.stage,
-    count: Number(r.count),
-  }));
-
-  const growthData = (growthRes.data ?? []).map((r: any) => ({
-    date: r.date,
-    signups: Number(r.signups),
-    cumulative_users: Number(r.cumulative_users),
+  const growthData = ((growthRes.data ?? []) as GrowthRow[]).map((row) => ({
+    date: row.date,
+    signups: Number(row.signups),
+    cumulative_users: Number(row.cumulative_users),
   }));
 
   const totalSpend =
@@ -79,14 +113,14 @@ export default async function AdminPage() {
       ? spendData[spendData.length - 1].cumulative_total
       : 0;
   const totalUsers =
-    funnelData.find((s: any) => s.stage === "signed_up")?.count ?? 0;
+    funnelData.find((stage) => stage.stage === "signed_up")?.count ?? 0;
 
   const isDummy = (id: string) => id.startsWith("a0000000-0000-4000-8000-");
-  const uniqueReal = (rows: any[]) =>
-    new Set(rows.filter((r) => !isDummy(r.user_id)).map((r) => r.user_id)).size;
+  const uniqueReal = (rows: DailyUsageUserRow[]) =>
+    new Set(rows.filter((row) => !isDummy(row.user_id)).map((row) => row.user_id)).size;
 
-  const dau = uniqueReal(dauRes.data ?? []);
-  const wau = uniqueReal(wauRes.data ?? []);
+  const dau = uniqueReal((dauRes.data ?? []) as DailyUsageUserRow[]);
+  const wau = uniqueReal((wauRes.data ?? []) as DailyUsageUserRow[]);
 
   // WoW spend growth: compare last 7 days vs prior 7 days
   const now = Date.now();
@@ -107,14 +141,14 @@ export default async function AdminPage() {
       ? ((thisWeekSpend - lastWeekSpend) / lastWeekSpend) * 100
       : null;
 
-  const promptRows = (promptsRes.data ?? []).map((r: any) => ({
-    id: r.id,
-    prompt: r.prompt,
-    is_anonymous: r.is_anonymous,
-    status: r.status,
-    is_hidden: r.is_hidden,
-    created_at: r.created_at,
-    user: r.user,
+  const promptRows = ((promptsRes.data ?? []) as PromptInboxRow[]).map((row) => ({
+    id: row.id,
+    prompt: row.prompt,
+    is_anonymous: row.is_anonymous,
+    status: row.status,
+    is_hidden: row.is_hidden,
+    created_at: row.created_at,
+    user: firstRelation(row.user),
   }));
 
   const spendFormatted = totalSpend.toLocaleString("en-US", {

--- a/apps/web/app/api/admin/cohort-retention/route.ts
+++ b/apps/web/app/api/admin/cohort-retention/route.ts
@@ -3,6 +3,16 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { isAdmin } from "@/lib/admin";
 
+type CohortRetentionRow = {
+  cohort_week: string;
+  cohort_size: number | string;
+  week_0: number | string | null;
+  week_1: number | string | null;
+  week_2: number | string | null;
+  week_3: number | string | null;
+  week_4: number | string | null;
+};
+
 export async function GET() {
   const auth = await createClient();
   const {
@@ -20,14 +30,14 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  const rows = (data ?? []).map((r: any) => ({
-    cohort_week: r.cohort_week,
-    cohort_size: Number(r.cohort_size),
-    week_0: r.week_0 !== null ? Number(r.week_0) : null,
-    week_1: r.week_1 !== null ? Number(r.week_1) : null,
-    week_2: r.week_2 !== null ? Number(r.week_2) : null,
-    week_3: r.week_3 !== null ? Number(r.week_3) : null,
-    week_4: r.week_4 !== null ? Number(r.week_4) : null,
+  const rows = ((data ?? []) as CohortRetentionRow[]).map((row) => ({
+    cohort_week: row.cohort_week,
+    cohort_size: Number(row.cohort_size),
+    week_0: row.week_0 !== null ? Number(row.week_0) : null,
+    week_1: row.week_1 !== null ? Number(row.week_1) : null,
+    week_2: row.week_2 !== null ? Number(row.week_2) : null,
+    week_3: row.week_3 !== null ? Number(row.week_3) : null,
+    week_4: row.week_4 !== null ? Number(row.week_4) : null,
   }));
 
   return NextResponse.json(rows);

--- a/apps/web/app/api/admin/model-usage/route.ts
+++ b/apps/web/app/api/admin/model-usage/route.ts
@@ -3,6 +3,12 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { isAdmin } from "@/lib/admin";
 
+type ModelUsageRow = {
+  date: string;
+  claude_spend: number | string;
+  codex_spend: number | string;
+};
+
 export async function GET() {
   const auth = await createClient();
   const {
@@ -20,10 +26,10 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  const rows = (data ?? []).map((r: any) => ({
-    date: r.date,
-    claude_spend: Number(r.claude_spend),
-    codex_spend: Number(r.codex_spend),
+  const rows = ((data ?? []) as ModelUsageRow[]).map((row) => ({
+    date: row.date,
+    claude_spend: Number(row.claude_spend),
+    codex_spend: Number(row.codex_spend),
   }));
 
   return NextResponse.json(rows);

--- a/apps/web/app/api/admin/revenue-concentration/route.ts
+++ b/apps/web/app/api/admin/revenue-concentration/route.ts
@@ -3,6 +3,13 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { isAdmin } from "@/lib/admin";
 
+type RevenueConcentrationRow = {
+  segment: string;
+  user_count: number | string;
+  total_spend: number | string;
+  pct_of_total: number | string;
+};
+
 export async function GET() {
   const auth = await createClient();
   const {
@@ -20,11 +27,11 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  const rows = (data ?? []).map((r: any) => ({
-    segment: r.segment,
-    user_count: Number(r.user_count),
-    total_spend: Number(r.total_spend),
-    pct_of_total: Number(r.pct_of_total),
+  const rows = ((data ?? []) as RevenueConcentrationRow[]).map((row) => ({
+    segment: row.segment,
+    user_count: Number(row.user_count),
+    total_spend: Number(row.total_spend),
+    pct_of_total: Number(row.pct_of_total),
   }));
 
   return NextResponse.json(rows);

--- a/apps/web/app/api/admin/time-to-first-sync/route.ts
+++ b/apps/web/app/api/admin/time-to-first-sync/route.ts
@@ -3,6 +3,12 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { isAdmin } from "@/lib/admin";
 
+type TimeToFirstSyncRow = {
+  bucket: string;
+  bucket_order: number | string;
+  user_count: number | string;
+};
+
 export async function GET() {
   const auth = await createClient();
   const {
@@ -20,10 +26,10 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  const rows = (data ?? []).map((r: any) => ({
-    bucket: r.bucket,
-    bucket_order: Number(r.bucket_order),
-    user_count: Number(r.user_count),
+  const rows = ((data ?? []) as TimeToFirstSyncRow[]).map((row) => ({
+    bucket: row.bucket,
+    bucket_order: Number(row.bucket_order),
+    user_count: Number(row.user_count),
   }));
 
   return NextResponse.json(rows);

--- a/apps/web/app/api/feed/route.ts
+++ b/apps/web/app/api/feed/route.ts
@@ -1,5 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { normalizeCommentPreview, normalizeFeedPost, type JoinedUserSummary, type RawCommentPreviewRow } from "@/lib/feed-normalization";
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { CommentPreviewItem, FeedPostRow, Post, UserSummary } from "@/types";
+
+type KudosRow = {
+  post_id: string;
+  user: JoinedUserSummary;
+};
 
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
@@ -31,20 +39,21 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const { data: posts, error } = await supabase.rpc("get_feed", {
+  const { data: rpcPosts, error } = await supabase.rpc("get_feed", {
     p_type: type,
     p_user_id: user?.id ?? null,
     p_limit: limit,
     p_cursor_date: cursorDate,
     p_cursor_created_at: cursorCreatedAt,
   });
+  const posts = ((rpcPosts ?? []) as FeedPostRow[]).map(normalizeFeedPost);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
   // Enrich with kudos status, kudos users, and recent comments — all in parallel
-  const postIds = (posts ?? []).map((p: any) => p.id);
+  const postIds = posts.map((post) => post.id);
 
   const [{ data: userKudos }, { data: recentKudos, error: kudosError }, { data: recentComments }] =
     postIds.length
@@ -70,7 +79,11 @@ export async function GET(request: NextRequest) {
             .order("created_at", { ascending: false })
             .limit(Math.min(postIds.length * 2, 40)),
         ])
-      : [{ data: [] as any[] }, { data: [] as any[], error: null }, { data: [] as any[] }];
+      : [
+          { data: [] as { post_id: string }[] },
+          { data: [] as KudosRow[], error: null },
+          { data: [] as RawCommentPreviewRow[] },
+        ];
 
   if (kudosError) {
     console.error("[feed] kudos users fetch error:", kudosError);
@@ -79,20 +92,21 @@ export async function GET(request: NextRequest) {
   const kudosedSet = new Set((userKudos ?? []).map((k) => k.post_id));
 
   const kudosUsersMap = new Map<string, Array<{ avatar_url: string | null; username: string | null }>>();
-  for (const k of recentKudos ?? []) {
-    const list = kudosUsersMap.get(k.post_id) ?? [];
-    if (list.length < 3) {
-      list.push(k.user as any);
-      kudosUsersMap.set(k.post_id, list);
+  for (const kudos of (recentKudos ?? []) as KudosRow[]) {
+    const list = kudosUsersMap.get(kudos.post_id) ?? [];
+    const userSummary = firstRelation(kudos.user);
+    if (list.length < 3 && userSummary) {
+      list.push(userSummary);
+      kudosUsersMap.set(kudos.post_id, list);
     }
   }
 
-  const commentsMap = new Map<string, Array<any>>();
-  for (const c of recentComments ?? []) {
-    const list = commentsMap.get(c.post_id) ?? [];
+  const commentsMap = new Map<string, CommentPreviewItem[]>();
+  for (const comment of (recentComments ?? []) as RawCommentPreviewRow[]) {
+    const list = commentsMap.get(comment.post_id) ?? [];
     if (list.length < 2) {
-      list.push(c);
-      commentsMap.set(c.post_id, list);
+      list.push(normalizeCommentPreview(comment));
+      commentsMap.set(comment.post_id, list);
     }
   }
   // Reverse to chronological order for display
@@ -100,13 +114,11 @@ export async function GET(request: NextRequest) {
     list.reverse();
   }
 
-  const enriched = (posts ?? []).map((p: any) => ({
-    ...p,
-    kudos_count: typeof p.kudos_count === "number" ? p.kudos_count : p.kudos_count?.[0]?.count ?? 0,
-    kudos_users: kudosUsersMap.get(p.id) ?? [],
-    comment_count: typeof p.comment_count === "number" ? p.comment_count : p.comment_count?.[0]?.count ?? 0,
-    recent_comments: commentsMap.get(p.id) ?? [],
-    has_kudosed: kudosedSet.has(p.id),
+  const enriched = posts.map((post) => ({
+    ...post,
+    kudos_users: kudosUsersMap.get(post.id) ?? [],
+    recent_comments: commentsMap.get(post.id) ?? [],
+    has_kudosed: kudosedSet.has(post.id),
   }));
 
   // Build composite cursor: "date|created_at"
@@ -120,7 +132,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Include pending posts (sessions without details) for any tab
-  let pending_posts: any[] = [];
+  let pending_posts: Post[] = [];
   if (user && !cursor) {
     const { data } = await supabase
       .from("posts")
@@ -130,7 +142,7 @@ export async function GET(request: NextRequest) {
       .eq("images", "[]")
       .order("created_at", { ascending: false })
       .limit(5);
-    pending_posts = data ?? [];
+    pending_posts = ((data ?? []) as FeedPostRow[]).map(normalizeFeedPost);
   }
 
   return NextResponse.json({ posts: enriched, next_cursor, pending_posts });

--- a/apps/web/app/api/usage/submit/route.ts
+++ b/apps/web/app/api/usage/submit/route.ts
@@ -179,7 +179,7 @@ export async function POST(request: Request) {
       const action: "created" | "updated" = existing ? "updated" : "created";
 
       let usage: { id: string } | null = null;
-      let usageError: any = null;
+      let usageErrorMessage: string | null = null;
       let titleCostUSD: number;
       let titleModels: string[] | undefined;
 
@@ -265,7 +265,7 @@ export async function POST(request: Request) {
           .single();
 
         usage = data;
-        usageError = error;
+        usageErrorMessage = error?.message ?? null;
         titleCostUSD = agg.cost_usd;
         titleModels = agg.models;
       } else {
@@ -296,7 +296,7 @@ export async function POST(request: Request) {
             .single();
 
           usage = data;
-          usageError = error;
+          usageErrorMessage = error?.message ?? null;
           titleCostUSD = entry.data.costUSD;
           titleModels = entry.data.models;
         } else {
@@ -307,8 +307,8 @@ export async function POST(request: Request) {
         }
       }
 
-      if (usageError || !usage) {
-        throw new Error(`Failed to upsert usage for ${entry.date}: ${usageError?.message}`);
+      if (usageErrorMessage || !usage) {
+        throw new Error(`Failed to upsert usage for ${entry.date}: ${usageErrorMessage ?? "Unknown error"}`);
       }
 
       // Build auto-title from aggregated usage data
@@ -340,7 +340,7 @@ export async function POST(request: Request) {
         .maybeSingle();
 
       let post: { id: string } | null = null;
-      let postError: any = null;
+      let postErrorMessage: string | null = null;
 
       if (existingPost) {
         // Auto-generated titles match "Mon DD" or "Mon DD — Models, $X.XX"
@@ -355,7 +355,7 @@ export async function POST(request: Request) {
           .select("id")
           .single();
         post = data;
-        postError = error;
+        postErrorMessage = error?.message ?? null;
       } else {
         const { data, error } = await db
           .from("posts")
@@ -368,11 +368,11 @@ export async function POST(request: Request) {
           .select("id")
           .single();
         post = data;
-        postError = error;
+        postErrorMessage = error?.message ?? null;
       }
 
-      if (postError || !post) {
-        throw new Error(`Failed to create post for ${entry.date}: ${postError?.message}`);
+      if (postErrorMessage || !post) {
+        throw new Error(`Failed to create post for ${entry.date}: ${postErrorMessage ?? "Unknown error"}`);
       }
 
       return {

--- a/apps/web/app/api/users/[username]/route.ts
+++ b/apps/web/app/api/users/[username]/route.ts
@@ -18,6 +18,9 @@ type PublicProfileRow = {
   referred_by: string | null;
   created_at: string;
 };
+type TotalCostAggregateRow = {
+  cost_usd: number | string | null;
+};
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const { username } = await context.params;
@@ -81,7 +84,8 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   ]);
 
   const streak = typeof streakRes.data === "number" ? streakRes.data : 0;
-  const total_cost = Number((totalCostRes.data as any)?.[0]?.cost_usd ?? 0);
+  const totalCostRows = totalCostRes.data as TotalCostAggregateRow[] | null;
+  const total_cost = Number(totalCostRows?.[0]?.cost_usd ?? 0);
   const is_following = !isOwn && !!authUserId && isFollowing;
 
   // Rank queries (depend on weekly leaderboard entry)

--- a/apps/web/lib/achievements.ts
+++ b/apps/web/lib/achievements.ts
@@ -31,6 +31,15 @@ export interface AchievementDef {
   check: (stats: AchievementStats) => boolean;
 }
 
+interface FirstWeekStats {
+  count: number;
+}
+
+interface ReferralStats {
+  crewSize: number;
+  crewTotalSpend: number;
+}
+
 export const ACHIEVEMENTS: AchievementDef[] = [
   {
     slug: "first-photo",
@@ -430,15 +439,15 @@ export async function checkAndAwardAchievements(
     streak: (streakResult?.data as number) ?? 0,
     syncCount: Number(usageRow?.sync_count ?? 0),
     verifiedSyncCount: Number(usageRow?.verified_sync_count ?? 0),
-    syncsInFirstWeek: (firstWeekResult as any)?.count ?? 0,
+    syncsInFirstWeek: (firstWeekResult as FirstWeekStats | null)?.count ?? 0,
     // Self-interactions (kudos/comments on own posts) are counted intentionally.
     kudosReceived: Number(socialRow?.kudos_received ?? 0),
     kudosSent: Number(socialRow?.kudos_sent ?? 0),
     commentsReceived: Number(socialRow?.comments_received ?? 0),
     commentsSent: Number(socialRow?.comments_sent ?? 0),
-    hasPhoto: (photoResult?.data as any[] | null)?.length ? true : false,
-    crewSize: (referralResult as any)?.crewSize ?? 0,
-    crewTotalSpend: (referralResult as any)?.crewTotalSpend ?? 0,
+    hasPhoto: (photoResult?.data ?? []).length > 0,
+    crewSize: (referralResult as ReferralStats | null)?.crewSize ?? 0,
+    crewTotalSpend: (referralResult as ReferralStats | null)?.crewTotalSpend ?? 0,
   };
 
   const newAwards = candidates.filter(

--- a/apps/web/lib/comments.ts
+++ b/apps/web/lib/comments.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Comment } from "@/types";
 
 export interface CommentReactionRow {
@@ -6,7 +7,7 @@ export interface CommentReactionRow {
 }
 
 export async function loadPostComments(opts: {
-  supabase: any;
+  supabase: SupabaseClient;
   postId: string;
   viewerId?: string | null;
   limit?: number;

--- a/apps/web/lib/feed-normalization.ts
+++ b/apps/web/lib/feed-normalization.ts
@@ -1,0 +1,26 @@
+import { firstRelation } from "@/lib/utils/first-relation";
+import type { CommentPreviewItem, FeedPostRow, Post, UserSummary } from "@/types";
+
+export type JoinedUserSummary = UserSummary[] | null;
+
+export type RawCommentPreviewRow = Omit<CommentPreviewItem, "user"> & {
+  user: JoinedUserSummary;
+};
+
+export function normalizeFeedPost(post: FeedPostRow): Post {
+  return {
+    ...post,
+    kudos_count: typeof post.kudos_count === "number" ? post.kudos_count : post.kudos_count?.[0]?.count ?? 0,
+    comment_count: typeof post.comment_count === "number" ? post.comment_count : post.comment_count?.[0]?.count ?? 0,
+  };
+}
+
+export function normalizeCommentPreview(comment: RawCommentPreviewRow): CommentPreviewItem {
+  return {
+    id: comment.id,
+    post_id: comment.post_id,
+    content: comment.content,
+    created_at: comment.created_at,
+    user: firstRelation(comment.user) ?? undefined,
+  };
+}

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -42,6 +42,7 @@ export async function updateSession(request: NextRequest) {
   }
 
   let supabaseResponse = NextResponse.next({ request });
+  type CookieOptions = Parameters<typeof supabaseResponse.cookies.set>[2];
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -51,13 +52,13 @@ export async function updateSession(request: NextRequest) {
         getAll() {
           return request.cookies.getAll();
         },
-        setAll(cookiesToSet: { name: string; value: string; options?: Record<string, unknown> }[]) {
+        setAll(cookiesToSet: { name: string; value: string; options?: CookieOptions }[]) {
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
           );
           supabaseResponse = NextResponse.next({ request });
           cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options as any)
+            supabaseResponse.cookies.set(name, value, options)
           );
         },
       },

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -5,6 +5,7 @@ import { getSupabaseBrowserEnv } from "./env";
 export async function createClient() {
   const cookieStore = await cookies();
   const env = getSupabaseBrowserEnv();
+  type CookieOptions = Parameters<typeof cookieStore.set>[2];
   return createServerClient(
     env.url,
     env.publishableKey,
@@ -13,9 +14,9 @@ export async function createClient() {
         getAll() {
           return cookieStore.getAll();
         },
-        setAll(cookiesToSet: { name: string; value: string; options?: Record<string, unknown> }[]) {
+        setAll(cookiesToSet: { name: string; value: string; options?: CookieOptions }[]) {
           cookiesToSet.forEach(({ name, value, options }) =>
-            cookieStore.set(name, value, options as any)
+            cookieStore.set(name, value, options)
           );
         },
       },

--- a/apps/web/lib/utils/first-relation.ts
+++ b/apps/web/lib/utils/first-relation.ts
@@ -1,0 +1,3 @@
+export function firstRelation<T>(value: T[] | null | undefined): T | null {
+  return value?.[0] ?? null;
+}

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -58,7 +58,7 @@ export interface Post {
   kudos_count?: number;
   kudos_users?: Array<Pick<User, "avatar_url" | "username">>;
   comment_count?: number;
-  recent_comments?: Array<Comment>;
+  recent_comments?: Array<CommentPreviewItem>;
   has_kudosed?: boolean;
 }
 
@@ -75,6 +75,34 @@ export interface Comment {
   has_reacted?: boolean;
   reply_count?: number;
   replies?: Comment[];
+}
+
+export interface AggregateCount {
+  count: number;
+}
+
+export interface UserSummary {
+  username: string | null;
+  avatar_url: string | null;
+}
+
+export interface CommentPreview extends Pick<Comment, "id" | "post_id" | "content" | "created_at"> {
+  user: UserSummary | null;
+}
+
+export interface CommentPreviewItem {
+  id: string;
+  post_id: string;
+  content: string;
+  created_at: string;
+  user?: UserSummary;
+}
+
+export interface FeedPostRow extends Omit<Post, "user" | "daily_usage" | "kudos_count" | "comment_count" | "kudos_users" | "recent_comments"> {
+  user: User;
+  daily_usage: DailyUsage;
+  kudos_count: number | AggregateCount[];
+  comment_count: number | AggregateCount[];
 }
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
## Summary
- remove `no-explicit-any` usage from the runtime app slice under `apps/web/app`, `apps/web/components`, `apps/web/lib`, and `apps/web/types`
- add shared feed/comment relation normalization helpers so joined Supabase rows are flattened in one place
- update the leaderboard flow test harness to match the current service-client read path

## Verification
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web test __tests__/api/leaderboard.test.ts __tests__/api/profile.test.ts __tests__/api/usage-submit.test.ts __tests__/api/feed.test.ts __tests__/api/contributions.test.ts __tests__/flows/profile-and-contributions.test.ts __tests__/flows/leaderboard-ranking.test.ts`
- `bun --cwd apps/web eslint app components lib types` filtered to `no-explicit-any` produced no matches

## Scope note
- this PR cleans the runtime/app slice only
- the larger `no-explicit-any` debt in `apps/web/__tests__` is still outstanding and should be handled in a follow-up test-focused cleanup PR