### PR TITLE
perf: reduce authenticated app shell startup latency

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -51,7 +51,7 @@ export default async function AppLayout({
     followersRes,
     postsRes,
     latestPostRes,
-    allTimeUsageRes,
+    usageTotalsRes,
     photoAchievementRes,
   ] = await Promise.all([
     supabase
@@ -77,10 +77,7 @@ export default async function AppLayout({
       .eq("user_id", user.id)
       .order("created_at", { ascending: false })
       .limit(3),
-    supabase
-      .from("daily_usage")
-      .select("cost_usd, output_tokens")
-      .eq("user_id", user.id),
+    supabase.rpc("get_user_usage_totals", { p_user_id: user.id }),
     supabase
       .from("user_achievements")
       .select("id")
@@ -104,10 +101,9 @@ export default async function AppLayout({
   const hasPhotoAchievement = !!photoAchievementRes.data;
   const showPhotoNudge = postsCount > 0 && !hasPhotoAchievement && !onboardingIncomplete;
 
-  const totalOutputTokens =
-    allTimeUsageRes.data?.reduce((s, r) => s + Number(r.output_tokens), 0) ?? 0;
-  const totalCost =
-    allTimeUsageRes.data?.reduce((s, r) => s + Number(r.cost_usd), 0) ?? 0;
+  const usageTotals = usageTotalsRes.data?.[0];
+  const totalOutputTokens = Number(usageTotals?.total_output_tokens ?? 0);
+  const totalCost = Number(usageTotals?.total_cost ?? 0);
 
   const latestPosts = ((latestPostRes.data ?? []) as LatestPostRow[])
     .map((row) => {
@@ -145,7 +141,11 @@ export default async function AppLayout({
         </div>
       }
     >
-      <RightSidebar userId={user.id} />
+      <RightSidebar
+        userId={user.id}
+        username={profile?.username ?? null}
+        totalOutputTokens={totalOutputTokens}
+      />
     </Suspense>
   );
 

--- a/apps/web/components/app/shared/RightSidebar.tsx
+++ b/apps/web/components/app/shared/RightSidebar.tsx
@@ -6,13 +6,23 @@ import { Avatar } from "@/components/ui/Avatar";
 import { FollowButton } from "@/components/app/profile/FollowButton";
 import { InviteButton } from "@/components/app/profile/InviteButton";
 
-export async function RightSidebar({ userId }: { userId: string }) {
+interface RightSidebarProps {
+  userId: string;
+  username: string | null;
+  totalOutputTokens: number;
+}
+
+export async function RightSidebar({
+  userId,
+  username,
+  totalOutputTokens,
+}: RightSidebarProps) {
   const supabase = await createClient();
   // Service client so suggestions can include all users.
   const service = getServiceClient();
 
   // Start independent queries in parallel (avoid waterfall)
-  const [{ data: topUsers }, { data: following }, { data: userUsage }, { data: userProfile }] = await Promise.all([
+  const [{ data: topUsers }, { data: following }] = await Promise.all([
     supabase
       .from("leaderboard_weekly")
       .select("user_id, username, avatar_url, total_cost")
@@ -22,15 +32,6 @@ export async function RightSidebar({ userId }: { userId: string }) {
       .from("follows")
       .select("following_id")
       .eq("follower_id", userId),
-    supabase
-      .from("daily_usage")
-      .select("output_tokens")
-      .eq("user_id", userId),
-    supabase
-      .from("users")
-      .select("username")
-      .eq("id", userId)
-      .single(),
   ]);
 
   const followingIds = following?.map((f) => f.following_id) ?? [];
@@ -90,9 +91,8 @@ export async function RightSidebar({ userId }: { userId: string }) {
   }
   const suggested = merged.slice(0, 5);
 
-  const userOutputTokens = userUsage?.reduce((s, r) => s + Number(r.output_tokens), 0) ?? 0;
   const TARGET = 1_000_000_000;
-  const pct = Math.min((userOutputTokens / TARGET) * 100, 100);
+  const pct = Math.min((totalOutputTokens / TARGET) * 100, 100);
 
   return (
     <div className="flex flex-col">
@@ -131,7 +131,7 @@ export async function RightSidebar({ userId }: { userId: string }) {
         <p className="text-sm font-semibold">The Three Comma Club</p>
         <p className="mb-3 text-xs text-muted">First to one billion output tokens</p>
         <div className="mb-1 flex items-center justify-between text-xs text-muted">
-          <span>{formatTokens(userOutputTokens)} ({pct < 0.01 ? '<0.01' : pct.toFixed(2)}%)</span>
+          <span>{formatTokens(totalOutputTokens)} ({pct < 0.01 ? '<0.01' : pct.toFixed(2)}%)</span>
           <span>1B</span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-subtle">
@@ -181,7 +181,7 @@ export async function RightSidebar({ userId }: { userId: string }) {
       </div>
 
       {/* Referral CTA */}
-      {userProfile?.username && (
+      {username && (
         <div className="border-b border-border p-6">
           <p className="mb-1 text-xs font-semibold uppercase tracking-widest text-muted">
             Grow Your Crew
@@ -189,7 +189,7 @@ export async function RightSidebar({ userId }: { userId: string }) {
           <p className="mb-3 text-sm text-muted">
             Invite a training partner. See who racks up more.
           </p>
-          <InviteButton username={userProfile.username} />
+          <InviteButton username={username} />
         </div>
       )}
 

--- a/supabase/migrations/20260403073000_add_get_user_usage_totals_rpc.sql
+++ b/supabase/migrations/20260403073000_add_get_user_usage_totals_rpc.sql
@@ -1,0 +1,27 @@
+-- Fast per-user usage totals for app chrome and profile surfaces.
+-- Prevents transferring full daily_usage history to the app server.
+CREATE OR REPLACE FUNCTION public.get_user_usage_totals(p_user_id uuid)
+RETURNS TABLE (
+  total_cost numeric,
+  total_output_tokens bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT
+    COALESCE(SUM(d.cost_usd), 0)::numeric AS total_cost,
+    COALESCE(SUM(d.output_tokens), 0)::bigint AS total_output_tokens
+  FROM public.daily_usage d
+  WHERE d.user_id = p_user_id
+    AND (
+      auth.uid() = p_user_id
+      OR auth.role() = 'service_role'
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.get_user_usage_totals(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_user_usage_totals(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_user_usage_totals(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_usage_totals(uuid) TO service_role;


### PR DESCRIPTION
## Summary
- add `get_user_usage_totals` RPC to compute lifetime cost/output in one DB aggregate call
- update app layout to use the aggregate RPC instead of loading all `daily_usage` rows per request
- pass `username` and `totalOutputTokens` from layout into `RightSidebar` to remove duplicate queries
- stream the right sidebar behind `Suspense` so right-rail fetches no longer block initial main-content render

## Testing
- `bun --cwd apps/web test __tests__/api/feed.test.ts`
- `bun --cwd apps/web typecheck` *(fails due to pre-existing missing `heic2any` module declaration)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Backend now returns consolidated user usage totals for faster, more efficient aggregation.
  * Right sidebar uses precomputed totals for the “Three Comma Club” progress and displays referral CTA using the resolved username.
* **New Features**
  * Added a server-side call to fetch single-row usage totals for each user, reducing client-side queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->