### PR TITLE
Harden dm attachment storage access

### DIFF
--- a/supabase/migrations/20260310065245_add_dm_attachments.sql
+++ b/supabase/migrations/20260310065245_add_dm_attachments.sql
@@ -17,12 +17,12 @@ ALTER TABLE public.direct_messages
     OR (attachments IS NOT NULL AND jsonb_array_length(attachments) > 0)
   );
 
--- 3. Create public dm-attachments storage bucket
+-- 3. Create private dm-attachments storage bucket
 INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
 VALUES (
   'dm-attachments',
   'dm-attachments',
-  true,
+  false,
   10485760,
   ARRAY[
     'image/jpeg', 'image/png', 'image/gif', 'image/webp',
@@ -32,7 +32,8 @@ VALUES (
     'application/json',
     'application/zip'
   ]
-) ON CONFLICT (id) DO NOTHING;
+) ON CONFLICT (id) DO UPDATE SET
+  public = false;
 
 -- 4. Storage policies for dm-attachments
 CREATE POLICY "Authenticated users can upload dm attachments"
@@ -43,9 +44,13 @@ CREATE POLICY "Authenticated users can upload dm attachments"
     AND (auth.uid())::text = (storage.foldername(name))[1]
   );
 
-CREATE POLICY "Anyone can view dm attachments"
+CREATE POLICY "Users can view own dm attachments"
   ON storage.objects FOR SELECT
-  USING (bucket_id = 'dm-attachments');
+  USING (
+    bucket_id = 'dm-attachments'
+    AND auth.role() = 'authenticated'
+    AND (auth.uid())::text = (storage.foldername(name))[1]
+  );
 
 CREATE POLICY "Users can delete own dm attachments"
   ON storage.objects FOR DELETE


### PR DESCRIPTION
### Motivation
- A migration created the `dm-attachments` storage bucket as public and added an unrestricted `SELECT` policy, which made direct-message attachments world-readable and bypassed the intended signed-URL/private access model. 
- The change restores alignment with existing docs and seed behavior that expect DM attachments to be private and only accessible via signed URLs.

### Description
- Change the `dm-attachments` bucket creation to set `public = false` and update the comment to indicate a private bucket. 
- Make `ON CONFLICT (id)` enforce privacy by updating `public = false` so reconciliation/reruns cannot leave the bucket public. 
- Replace the world-readable SELECT policy with an authenticated, owner-folder-scoped SELECT policy that requires `auth.role() = 'authenticated'` and `auth.uid()` to match the first path segment. 
- Kept the existing INSERT/DELETE policies for owner-only upload and deletion behavior.

### Testing
- Inspected the migration file with `sed -n '1,220p' supabase/migrations/20260310065245_add_dm_attachments.sql` and validated the changes via `git diff` and `nl -ba` outputs, which all succeeded. 
- Searched the repo for related references with `rg` to confirm application code expects signed URLs and the bucket name, which succeeded. 
- Committed the change with `git commit` after verifying the local diff, and could not run the migration end-to-end because the Supabase CLI is not available in this environment (attempt to run `supabase db reset` failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe4ae54d0832780968228d4b6b13c)