### PR TITLE
fix(web): escape JSON-LD payload on open stats page

### DIFF
--- a/apps/web/app/(landing)/open/page.tsx
+++ b/apps/web/app/(landing)/open/page.tsx
@@ -54,6 +54,13 @@ function segmentLabel(seg: string): string {
   }
 }
 
+function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 /* -------------------------------------------------------------------------- */
 /*  Page component                                                             */
 /* -------------------------------------------------------------------------- */
@@ -138,11 +145,11 @@ export default async function OpenStatsPage() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbLd) }}
       />
 
       <Navbar variant="light" />


### PR DESCRIPTION
### Motivation
- Prevent stored XSS where attacker-controlled model names from usage data could break out of the JSON-LD `<script>` and execute when `/open` is viewed.

### Description
- Add a small `serializeJsonLd` helper that escapes `<` and U+2028/U+2029 and use it in place of `JSON.stringify(...)` for both FAQ and breadcrumb JSON‑LD script tags in `apps/web/app/(landing)/open/page.tsx` to safely serialize the payload.

### Testing
- Ran `bun --cwd apps/web lint app/'(landing)'/open/page.tsx` and `bun --cwd apps/web typecheck`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe5fbce9c83278a98647af7b6c404)