### PR TITLE
fix(security): lock down dm attachment storage reads

### DIFF
--- a/supabase/migrations/20260403120000_harden_dm_attachment_storage.sql
+++ b/supabase/migrations/20260403120000_harden_dm_attachment_storage.sql
@@ -1,0 +1,29 @@
+-- Harden DM attachment storage privacy.
+-- DM attachments should never be publicly readable/listable.
+
+-- Ensure the bucket is private.
+UPDATE storage.buckets
+SET public = false
+WHERE id = 'dm-attachments';
+
+-- Remove overly broad read policy.
+DROP POLICY IF EXISTS "Anyone can view dm attachments" ON storage.objects;
+
+-- Allow reads only to authenticated users who are participants in a DM
+-- that references the exact attachment path.
+DROP POLICY IF EXISTS "DM participants can view dm attachments" ON storage.objects;
+
+CREATE POLICY "DM participants can view dm attachments"
+  ON storage.objects FOR SELECT
+  USING (
+    bucket_id = 'dm-attachments'
+    AND auth.role() = 'authenticated'
+    AND EXISTS (
+      SELECT 1
+      FROM public.direct_messages dm
+      WHERE (dm.sender_id = auth.uid() OR dm.recipient_id = auth.uid())
+        AND dm.attachments @> jsonb_build_array(
+          jsonb_build_object('bucket', 'dm-attachments', 'path', name)
+        )
+    )
+  );


### PR DESCRIPTION
### Motivation
- The original migration created the `dm-attachments` bucket as public and added a permissive SELECT policy, allowing unauthenticated listing and downloading of DM attachments. 
- The upload flow hands out storage object paths/URLs, so public storage + broad SELECT policy enabled enumeration and exfiltration of private DM attachments.

### Description
- Add a Supabase migration `supabase/migrations/20260403120000_harden_dm_attachment_storage.sql` that sets the `dm-attachments` bucket to private by updating `storage.buckets`.
- Drop the overly broad `"Anyone can view dm attachments"` SELECT policy and add a restrictive `"DM participants can view dm attachments"` SELECT policy that only allows authenticated users who are a sender or recipient of a direct message that references the exact attachment path. 
- This is a minimal, storage-layer fix that preserves existing upload and application behavior while enforcing DM-level access controls.

### Testing
- Ran the web API unit tests for upload and messages with `bunx vitest __tests__/api/upload.test.ts __tests__/api/messages.test.ts` from `apps/web`, and they passed (2 files, 28 tests). 
- Attempting `pnpm -s vitest ...` in this environment failed due to the package manager specification, but test execution succeeded under the repository's `bun` runner and no application code behavior was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe8d591d88327b71d52f80d432b66)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened privacy protection for direct message attachments. Only authenticated participants in a conversation can now access attachments shared in direct messages, preventing unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->