### PR TITLE
Harden SECURITY DEFINER get_feed RPC against user-id spoofing

### DIFF
--- a/supabase/migrations/20260403110000_harden_get_feed_rpc_auth.sql
+++ b/supabase/migrations/20260403110000_harden_get_feed_rpc_auth.sql
@@ -1,0 +1,86 @@
+-- Harden feed RPC authorization checks.
+-- SECURITY DEFINER is required to join related rows, so we enforce caller identity
+-- for private feed types before running the query.
+CREATE OR REPLACE FUNCTION public.get_feed(
+  p_type              text,
+  p_user_id           uuid        DEFAULT NULL,
+  p_limit             int         DEFAULT 20,
+  p_cursor_date       date        DEFAULT NULL,
+  p_cursor_created_at timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  id              uuid,
+  user_id         uuid,
+  daily_usage_id  uuid,
+  title           text,
+  description     text,
+  images          jsonb,
+  created_at      timestamptz,
+  updated_at      timestamptz,
+  "user"          jsonb,
+  daily_usage     jsonb,
+  kudos_count     bigint,
+  comment_count   bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_auth_user_id uuid := auth.uid();
+BEGIN
+  IF p_type IN ('mine', 'following') THEN
+    IF v_auth_user_id IS NULL OR p_user_id IS NULL OR p_user_id <> v_auth_user_id THEN
+      RAISE EXCEPTION 'Unauthorized'
+        USING ERRCODE = '42501';
+    END IF;
+  ELSIF p_type <> 'global' THEN
+    RAISE EXCEPTION 'Invalid feed type: %', p_type
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.user_id,
+    p.daily_usage_id,
+    p.title,
+    p.description,
+    p.images,
+    p.created_at,
+    p.updated_at,
+    to_jsonb(u.*) AS "user",
+    to_jsonb(d.*) AS daily_usage,
+    (SELECT COUNT(*) FROM public.kudos k WHERE k.post_id = p.id)   AS kudos_count,
+    (SELECT COUNT(*) FROM public.comments c WHERE c.post_id = p.id) AS comment_count
+  FROM public.posts p
+  JOIN public.users       u ON u.id = p.user_id
+  JOIN public.daily_usage d ON d.id = p.daily_usage_id
+  WHERE
+    CASE p_type
+      WHEN 'global'    THEN u.is_public = true
+      WHEN 'mine'      THEN p.user_id = p_user_id
+      WHEN 'following' THEN
+        p.user_id = p_user_id
+        OR EXISTS (
+          SELECT 1 FROM public.follows f
+          WHERE f.follower_id = p_user_id AND f.following_id = p.user_id
+        )
+      ELSE false
+    END
+    AND CASE
+      WHEN p_cursor_date IS NULL AND p_cursor_created_at IS NULL THEN true
+      WHEN p_cursor_date IS NOT NULL THEN
+        d.date < p_cursor_date
+        OR (d.date = p_cursor_date AND p.created_at < p_cursor_created_at)
+      ELSE
+        p.created_at < p_cursor_created_at
+    END
+  ORDER BY d.date DESC, p.created_at DESC
+  LIMIT p_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_feed(text, uuid, int, date, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_feed(text, uuid, int, date, timestamptz) TO anon;


### PR DESCRIPTION
### Motivation

- A SECURITY DEFINER `public.get_feed` RPC previously trusted a caller-provided `p_user_id` for `mine` and `following` feeds and was granted to `anon`, enabling user-id spoofing and RLS bypass for private data.
- The change aims to prevent unauthorized access to private posts and related `daily_usage` rows without removing the SECURITY DEFINER behavior needed for joins.
- The fix should be minimal and migration-only so application code and existing grants remain unchanged for the `global` feed.

### Description

- Added a new migration `supabase/migrations/20260403110000_harden_get_feed_rpc_auth.sql` that replaces `public.get_feed(...)` with an implementation that verifies caller identity.
- The function now captures `auth.uid()` into `v_auth_user_id` and raises `42501` if `p_type` is `mine` or `following` and `p_user_id` is missing or does not equal `auth.uid()`.
- The function raises `22023` for invalid feed types and otherwise preserves the original query, ordering, limit behavior, and `GRANT EXECUTE` lines for `authenticated` and `anon`.
- The change is intentionally minimal to harden authorization while keeping existing client APIs intact.

### Testing

- Searched migrations for the function with `rg -n "create or replace function public.get_feed|get_feed\(" supabase/migrations` and confirmed the original RPC exists; command completed successfully.
- Ran `git diff --check` to ensure no whitespace or diff issues and the check passed without errors.
- Verified the new migration file is staged/committed with `git status --short` and `git diff -- supabase/migrations/20260403110000_harden_get_feed_rpc_auth.sql`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfea28cbd48327903a0e9aa54ebbcc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened feed access control with enhanced user authentication validation for personalized and following feeds.
  * Added validation to reject invalid feed type requests.
  * Improved privacy enforcement to prevent unauthorized content access across different feed types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->