### PR TITLE
Validate caller in SECURITY DEFINER `get_following_feed` RPC

### DIFF
--- a/supabase/migrations/20260301000000_get_following_feed.sql
+++ b/supabase/migrations/20260301000000_get_following_feed.sql
@@ -24,7 +24,17 @@ STABLE
 SECURITY DEFINER
 SET search_path TO 'public'
 AS $$
+DECLARE
+  v_caller_id uuid := auth.uid();
 BEGIN
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  IF p_user_id IS DISTINCT FROM v_caller_id THEN
+    RAISE EXCEPTION 'Forbidden: p_user_id must match auth.uid()' USING ERRCODE = '42501';
+  END IF;
+
   RETURN QUERY
   SELECT
     p.id,
@@ -43,10 +53,10 @@ BEGIN
   JOIN public.users u ON u.id = p.user_id
   LEFT JOIN public.daily_usage d ON d.id = p.daily_usage_id
   WHERE (
-    p.user_id = p_user_id
+    p.user_id = v_caller_id
     OR EXISTS (
       SELECT 1 FROM public.follows f
-      WHERE f.follower_id = p_user_id AND f.following_id = p.user_id
+      WHERE f.follower_id = v_caller_id AND f.following_id = p.user_id
     )
   )
   AND (p_cursor IS NULL OR p.created_at < p_cursor)


### PR DESCRIPTION
### Motivation
- The `get_following_feed` migration created a `SECURITY DEFINER` RPC that accepted a caller-supplied `p_user_id`, which could bypass RLS and expose other users' private posts, user records, and `daily_usage` data.
- The intent is to prevent privilege escalation and privacy leaks by ensuring the function only returns data for the authenticated caller.

### Description
- Resolve the caller identity once with `v_caller_id := auth.uid()` and reject requests when `v_caller_id` is `NULL` to block unauthenticated access.
- Enforce that `p_user_id` must match the authenticated caller by raising an exception if `p_user_id IS DISTINCT FROM v_caller_id`, preserving the existing function signature and grants.
- Update the feed filtering logic to use the validated `v_caller_id` for both self posts and follow relationships so the function can no longer be used to read other users' feeds.

### Testing
- No automated test suite was executed for this change; validation consisted of static inspection of the updated migration file to confirm the `auth.uid()` check and predicate updates were applied as intended.
- Verified the change by running `git diff -- supabase/migrations/20260301000000_get_following_feed.sql` and committing the updated migration successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfec47a5a08327bae589310df7db66)