### PR TITLE
fix: prevent public caching of private stats card images

### DIFF
--- a/apps/web/app/api/stats/[username]/image/route.tsx
+++ b/apps/web/app/api/stats/[username]/image/route.tsx
@@ -52,15 +52,16 @@ export async function GET(request: NextRequest, context: RouteContext) {
       );
     }
 
-    // When a ?v= fingerprint is present the URL changes on new data,
-    // so the response can be cached indefinitely. Without it, fall back
-    // to a short TTL for direct / external hits.
+    // Private profiles are auth-gated and must never be cached by shared/CDN
+    // caches. Public profiles can keep long-lived fingerprinted caching.
     const hasFingerprint = request.nextUrl.searchParams.has("v");
     response.headers.set(
       "Cache-Control",
-      hasFingerprint
-        ? "public, max-age=31536000, s-maxage=31536000, immutable"
-        : "public, max-age=7200, s-maxage=7200, stale-while-revalidate=3600"
+      profile.is_public
+        ? hasFingerprint
+          ? "public, max-age=31536000, s-maxage=31536000, immutable"
+          : "public, max-age=7200, s-maxage=7200, stale-while-revalidate=3600"
+        : "private, no-store"
     );
 
     return response;


### PR DESCRIPTION
### Motivation
- Address a privacy leak where fingerprinted stats image URLs for private profiles were returned with a public, long-lived `Cache-Control`, allowing shared caches/CDNs to store and later serve private images to unauthorized users.
- Ensure auth-gated profile images are never cached by shared caches while preserving caching for public profiles.

### Description
- Change `Cache-Control` logic in `apps/web/app/api/stats/[username]/image/route.tsx` to return `private, no-store` for non-public profiles. 
- Preserve the existing fingerprint-based immutable caching (`public, max-age=31536000, s-maxage=31536000, immutable`) for public profiles when `?v=` is present, and the short TTL fallback for non-fingerprinted public requests. 
- Leave image generation and `Content-Disposition` behavior unchanged so functionality is preserved.

### Testing
- Ran the linter with `bun --cwd apps/web lint app/api/stats/[username]/image/route.tsx`, which completed successfully. 
- No automated unit or E2E tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02ac99404832799a5bed686da7db2)