### PR TITLE
fix: enforce profile access checks in radar endpoint

### DIFF
--- a/apps/web/app/api/users/[username]/radar/route.ts
+++ b/apps/web/app/api/users/[username]/radar/route.ts
@@ -1,23 +1,27 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { getServiceClient } from "@/lib/supabase/service";
 import { computeRadarScores } from "@/lib/radar";
+import { getProfileAccessContext } from "@/lib/profile-access";
 
 type RouteContext = { params: Promise<{ username: string }> };
+type RadarProfileRow = {
+  id: string;
+  is_public: boolean;
+};
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const { username } = await context.params;
-  const db = getServiceClient();
+  const access = await getProfileAccessContext<RadarProfileRow>(
+    username,
+    "id, is_public",
+  );
 
-  const { data: user, error: userError } = await db
-    .from("users")
-    .select("id")
-    .eq("username", username)
-    .single();
-
-  if (userError || !user) {
+  if (!access) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
+  if (!access.canView) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
-  const scores = await computeRadarScores(user.id);
+  const scores = await computeRadarScores(access.profile.id);
   return NextResponse.json(scores);
 }


### PR DESCRIPTION
### Motivation
- Close an access-control gap where the public `GET /api/users/[username]/radar` route used a service-role lookup and could return derived usage/community percentile stats for private profiles, bypassing RLS and the app's privacy model.

### Description
- Replace the direct service-role username lookup with `getProfileAccessContext` and request only `id, is_public` for the radar route. 
- Add a `RadarProfileRow` type and enforce the same visibility rules as other profile endpoints by returning `404` for missing users and `403` for unauthorized (private) profiles. 
- Preserve existing behavior for authorized viewers by calling `computeRadarScores` with the resolved `profile.id` and returning the computed scores. 
- Remove the unused `getServiceClient` usage from this route so heavy global queries remain server-side but are not exposed to unauthenticated callers.

### Testing
- Ran type checking with `cd apps/web && bun run typecheck`, which completed successfully. 
- Ran lint on the modified file with `cd apps/web && bun run lint app/api/users/[username]/radar/route.ts`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbddecc8327b2edd98a066f813e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the radar endpoint to properly return 404 when users are not found and 403 when access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->