### PR TITLE
fix(profile): restrict crew popover to public referred users

### DIFF
--- a/apps/web/app/(app)/u/[username]/page.tsx
+++ b/apps/web/app/(app)/u/[username]/page.tsx
@@ -165,6 +165,7 @@ export default async function ProfilePage({
       .from("users")
       .select("username, display_name, avatar_url")
       .eq("referred_by", profile.id)
+      .eq("is_public", true)
       .order("created_at", { ascending: true }),
     db
       .from("daily_usage")


### PR DESCRIPTION
### Motivation
- Prevent leaking private user profile fields by stopping a service-role query from returning referred users without a visibility check, which exposed `username`, `display_name`, and `avatar_url` for non-public users in the crew popover.

### Description
- Add `.eq("is_public", true)` to the referred-user query in `apps/web/app/(app)/u/[username]/page.tsx` so only publicly visible referred users are returned and passed to the `CrewPopover` client component.

### Testing
- Ran `bun run test __tests__/api/prompts.test.ts __tests__/api/search.test.ts`, which passed (2 files, 18 tests), and an attempted `pnpm --filter @straude/web test ...` invocation failed due to the repo specifying `bun` as the package manager.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbcfbdc8327b439c9cdaac27fb6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile pages now correctly filter to display only public user profiles in the recruitment list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->