### PR TITLE
fix(web): prevent SSRF in join OG avatar rendering

### DIFF
--- a/apps/web/app/(landing)/join/[username]/opengraph-image.tsx
+++ b/apps/web/app/(landing)/join/[username]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { getServiceClient } from "@/lib/supabase/service";
 import { loadFonts } from "@/lib/og-fonts";
+import { isFirstPartyPublicStorageUrl } from "@/lib/storage";
 
 export const alt = "Join Straude";
 export const size = { width: 1200, height: 630 };
@@ -24,6 +25,11 @@ export default async function Image({
   if (!referrer || !referrer.is_public) {
     return fallbackImage(fonts);
   }
+  const avatarUrl = referrer.avatar_url;
+  const safeAvatarUrl =
+    typeof avatarUrl === "string" && isFirstPartyPublicStorageUrl(avatarUrl, "avatars")
+      ? avatarUrl
+      : null;
 
   const now = new Date();
   const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
@@ -138,9 +144,9 @@ export default async function Image({
           }}
         >
           {/* Avatar */}
-          {referrer.avatar_url ? (
+          {safeAvatarUrl ? (
             <img
-              src={referrer.avatar_url}
+              src={safeAvatarUrl}
               alt=""
               width={120}
               height={120}


### PR DESCRIPTION
### Motivation
- Prevent SSRF introduced by server-side `ImageResponse` fetching unvalidated user-controlled `avatar_url` when rendering `/join/[username]` OG images.

### Description
- Import `isFirstPartyPublicStorageUrl` and validate `referrer.avatar_url` into a `safeAvatarUrl`, only passing a first-party Supabase `avatars` public URL into the OG `<img>` and falling back to the existing initials-based avatar when the URL is not a verified first-party storage URL.

### Testing
- Ran the linter: `bun --cwd apps/web eslint "app/(landing)/join/[username]/opengraph-image.tsx"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbc6d5483279bb8362ab4c9e1a3)