### PR TITLE
fix: prevent unauthorized reverse follow in referral attribution

### DIFF
--- a/apps/web/lib/referral.ts
+++ b/apps/web/lib/referral.ts
@@ -33,11 +33,11 @@ export async function attributeReferral(
     .eq("id", newUserId)
     .is("referred_by", null);
 
-  // Create mutual follows
+  // Auto-follow referrer so the new user sees their activity.
+  // Do not create a reverse follow on behalf of the referrer.
   await db.from("follows").upsert(
     [
       { follower_id: newUserId, following_id: referrer.id },
-      { follower_id: referrer.id, following_id: newUserId },
     ],
     { onConflict: "follower_id,following_id", ignoreDuplicates: true },
   );


### PR DESCRIPTION
### Motivation
- The referral attribution flow trusted a client-controlled `ref` cookie and created a reverse follow (`referrer -> new user`) using a service-role client, which allowed authenticated users to spoof referrals and force unauthorized follows.

### Description
- Remove the reverse follow insertion in `attributeReferral` (in `apps/web/lib/referral.ts`) so the upsert only creates `{ follower_id: newUserId, following_id: referrer.id }` while preserving referral metadata, notification, email, and achievement flows.

### Testing
- Ran `bun --cwd apps/web test __tests__/unit/achievements.test.ts`, which passed all tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbc683c832791bbc05ab3971018)