### PR TITLE
fix: enforce DM eligibility in direct_messages INSERT RLS policy

### DIFF
--- a/supabase/migrations/20260403120000_harden_direct_message_insert_policy.sql
+++ b/supabase/migrations/20260403120000_harden_direct_message_insert_policy.sql
@@ -1,0 +1,27 @@
+DROP POLICY IF EXISTS "Users can send direct messages" ON public.direct_messages;
+CREATE POLICY "Users can send direct messages"
+  ON public.direct_messages FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = sender_id
+    AND EXISTS (
+      SELECT 1
+      FROM public.users recipient
+      WHERE recipient.id = recipient_id
+        AND (
+          recipient.is_public
+          OR EXISTS (
+            SELECT 1
+            FROM public.direct_messages dm
+            WHERE (
+              dm.sender_id = sender_id
+              AND dm.recipient_id = recipient_id
+            )
+            OR (
+              dm.sender_id = recipient_id
+              AND dm.recipient_id = sender_id
+            )
+          )
+        )
+    )
+  );


### PR DESCRIPTION
### Motivation
- The previous INSERT RLS policy for `public.direct_messages` only enforced `auth.uid() = sender_id`, which allowed any authenticated client to create DMs to arbitrary recipients and bypass the API’s privacy checks.
- This could be used to create threads with private users and then retrieve private profile data via the security-definer `get_direct_message_threads` RPC, so the authorization must be enforced at the DB layer.

### Description
- Adds a new migration `supabase/migrations/20260403120000_harden_direct_message_insert_policy.sql` that replaces the `"Users can send direct messages"` INSERT policy.
- The new policy preserves `auth.uid() = sender_id` and additionally requires that the `recipient` is either `is_public` or that an existing DM pair (sender/recipient) already exists, using an `EXISTS` subquery against `public.users` and `public.direct_messages`.
- This aligns database-level RLS with the server-side `resolveConversationUser` check in `apps/web/app/api/messages/route.ts` so clients cannot bypass privacy rules by inserting rows directly.

### Testing
- Ran `bun test apps/web/__tests__/unit/migration-safety.test.ts`, which passed (5 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbcfdbc8327af5f3b7431566d2c)