### PR TITLE
fix(web): enforce post detail privacy checks

### DIFF
--- a/apps/web/app/(app)/post/[id]/page.tsx
+++ b/apps/web/app/(app)/post/[id]/page.tsx
@@ -12,7 +12,8 @@ import type { Metadata } from "next";
 type MetadataPostRow = {
   title: string | null;
   description: string | null;
-  user: Array<{ username: string | null }> | null;
+  user_id: string;
+  user: Array<{ username: string | null; is_public: boolean }> | null;
   daily_usage: Array<{
     cost_usd: number | null;
     output_tokens: number | null;
@@ -34,13 +35,32 @@ export async function generateMetadata({
   const { data: rawPost } = await supabase
     .from("posts")
     .select(
-      "title, description, user:users!posts_user_id_fkey(username), daily_usage:daily_usage!posts_daily_usage_id_fkey(cost_usd, output_tokens, models)"
+      "title, description, user_id, user:users!posts_user_id_fkey(username, is_public), daily_usage:daily_usage!posts_daily_usage_id_fkey(cost_usd, output_tokens, models)"
     )
     .eq("id", id)
     .single();
   const post = rawPost as MetadataPostRow | null;
 
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
   const userRow = firstRelation(post?.user);
+  const canView = Boolean(post) && (userRow?.is_public || authUser?.id === post?.user_id);
+
+  if (!canView) {
+    return {
+      title: "Post",
+      description: "This post is private.",
+      alternates: {
+        canonical: `/post/${id}`,
+      },
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
   const usageRow = firstRelation(post?.daily_usage);
   const username = userRow?.username ?? "user";
   const description =
@@ -153,6 +173,10 @@ export default async function PostDetailPage({
   ]);
 
   if (!post) notFound();
+
+  if (!post.user?.is_public && user?.id !== post.user_id) {
+    notFound();
+  }
 
   const hasKudosed = !!kudosCheck;
 


### PR DESCRIPTION
### Motivation
- A recent change narrowed route-level auth to exclude `/post/[id]`, which left post detail pages fetching joined `users` and `daily_usage` without verifying `users.is_public` or ownership, exposing private posts by ID.
- The intent of this change is to restore the original privacy guarantees for post detail pages without re-locking all `/post/*` routes.

### Description
- Updated the metadata query in `apps/web/app/(app)/post/[id]/page.tsx` to include `user_id` and `users.is_public` and added a viewer access check in `generateMetadata` that returns a minimal private/noindex metadata payload when the viewer is unauthorized.
- Added a runtime authorization gate in the post page render that calls `notFound()` when `post.user.is_public` is false and the requester is not the post owner, preserving owner edit access.
- Kept public post behavior unchanged so public posts remain viewable and owners retain full access and edit UI.

### Testing
- Ran type checking with `bun run --cwd apps/web typecheck`, which succeeded.
- Ran the privacy-related unit/flow tests with `bun run --cwd apps/web test __tests__/flows/privacy-visibility.test.ts`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbcb8cc8327899e016acb18d53e)