### PR TITLE
fix(web): block SSRF in share-image URL handling

### DIFF
--- a/apps/web/app/api/posts/[id]/share-image/route.tsx
+++ b/apps/web/app/api/posts/[id]/share-image/route.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { ShareCardImage } from "@/lib/utils/share-image";
 import { DEFAULT_SHARE_THEME, type ShareThemeId } from "@/lib/share-themes";
 import { loadFonts } from "@/lib/og-fonts";
+import { isFirstPartyPublicStorageUrl } from "@/lib/storage";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -50,6 +51,18 @@ export async function GET(request: NextRequest, context: RouteContext) {
     models: string[];
     is_verified: boolean;
   } | null;
+  const safeAvatarUrl =
+    typeof u?.avatar_url === "string" &&
+      isFirstPartyPublicStorageUrl(u.avatar_url, "avatars")
+      ? u.avatar_url
+      : null;
+  const safeImages = Array.isArray(post.images)
+    ? post.images.filter(
+        (image): image is string =>
+          typeof image === "string" &&
+          isFirstPartyPublicStorageUrl(image, "post-images"),
+      )
+    : [];
 
   try {
     const fonts = await loadFonts();
@@ -59,9 +72,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
         post={{
           title: post.title,
           description: post.description,
-          images: post.images ?? [],
+          images: safeImages,
           username: u?.username ?? "anonymous",
-          avatar_url: u?.avatar_url ?? null,
+          avatar_url: safeAvatarUrl,
           cost_usd: usage?.cost_usd ?? null,
           input_tokens: usage?.input_tokens ?? 0,
           output_tokens: usage?.output_tokens ?? 0,


### PR DESCRIPTION
### Motivation

- The share-image OG endpoint previously passed user-controlled `avatar_url` and `images` directly into server-side `ImageResponse` rendering, enabling an SSRF primitive when those URLs pointed to internal or remote endpoints.
- The change aims to prevent server-side fetches of arbitrary URLs while preserving legitimate first-party images used for share cards.

### Description

- Import `isFirstPartyPublicStorageUrl` from `@/lib/storage` and use it to validate user-provided image URLs in `apps/web/app/api/posts/[id]/share-image/route.tsx`.
- Compute `safeAvatarUrl` by allowing `u.avatar_url` only when it is a first-party `avatars` storage URL, otherwise set it to `null`.
- Filter `post.images` into `safeImages` to include only first-party `post-images` storage URLs and pass `safeImages`/`safeAvatarUrl` into `ShareCardImage` to avoid fetching untrusted URLs server-side.
- This change limits image rendering to application-hosted storage paths and keeps the rest of the share-image behavior intact.

### Testing

- Ran `bun run --cwd apps/web typecheck` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbc765c83279487b353a31ca267)