### PR TITLE
fix(cli): require trusted ccusage binary on PATH

### DIFF
--- a/packages/cli/__tests__/ccusage.test.ts
+++ b/packages/cli/__tests__/ccusage.test.ts
@@ -21,6 +21,11 @@ import { existsSync } from "node:fs";
 const mockExecFileSync = vi.mocked(execFileSync);
 const mockExistsSync = vi.mocked(existsSync);
 
+beforeEach(() => {
+  // Default to ccusage being available; individual tests can override.
+  mockExistsSync.mockReturnValue(true);
+});
+
 /** Build a valid ccusage v18 JSON string. */
 function validOutput() {
   return JSON.stringify({
@@ -182,20 +187,14 @@ describe("runCcusage", () => {
     );
   });
 
-  it("falls back to package runner when ccusage is not globally installed", () => {
+  it("throws when ccusage is not globally installed", () => {
     // ccusage not found on PATH
     mockExistsSync.mockReturnValue(false);
 
-    runCcusage("20250601", "20250601");
-
-    // Single call: npx fallback (process.versions.bun is undefined in Vitest env;
-    // bunx path is exercised when the CLI actually runs under bun)
-    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      "npx",
-      ["--yes", "ccusage@17", "daily", "--json", "--breakdown", "--since", "20250601", "--until", "20250601"],
-      expect.objectContaining({ encoding: "utf-8" }),
+    expect(() => runCcusage("20250601", "20250601")).toThrow(
+      "ccusage is not installed or not on PATH",
     );
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
   it("reports timeout when killed", () => {

--- a/packages/cli/__tests__/flows/cli-sync-flow.test.ts
+++ b/packages/cli/__tests__/flows/cli-sync-flow.test.ts
@@ -47,7 +47,10 @@ vi.mock("../../src/config.js", async (importOriginal) => {
 let configStore: Record<string, string> = {};
 
 vi.mock("node:fs", () => ({
-  existsSync: vi.fn((path: string) => path in configStore),
+  existsSync: vi.fn((path: string) =>
+    path in configStore
+    || /(^|[\\/])ccusage(\.cmd|\.exe)?$/.test(path),
+  ),
   readFileSync: vi.fn((path: string) => configStore[path] ?? ""),
   writeFileSync: vi.fn((path: string, data: string) => {
     configStore[path] = data;

--- a/packages/cli/src/lib/ccusage.ts
+++ b/packages/cli/src/lib/ccusage.ts
@@ -23,11 +23,6 @@ interface ExecError extends Error {
 /** Resolved ccusage command. Cached after first resolution. */
 let _resolved: { cmd: string; args: string[] } | undefined;
 
-// Pin to v17 — ccusage v18 uses the `runtime:` protocol in its dependencies,
-// which npm doesn't support (EUNSUPPORTEDPROTOCOL). Safe to unpin once ccusage
-// drops `runtime:` or npm adds support for it.
-const CCUSAGE_PKG = "ccusage@17";
-
 /** Check if a binary exists on PATH without spawning a subprocess. */
 function isOnPath(binary: string): boolean {
   const dirs = (process.env.PATH || "").split(delimiter);
@@ -38,33 +33,22 @@ function isOnPath(binary: string): boolean {
 }
 
 /**
- * Resolve the fastest available way to run ccusage.
- * 1. Direct `ccusage` binary on PATH (globally installed) — fastest
- * 2. `bunx` if running under Bun — no subprocess needed to detect
- * 3. `npx` fallback
+ * Resolve how to run ccusage.
+ * For security reasons we only execute an explicitly installed `ccusage`
+ * binary from PATH and do not auto-install/execute package-runner fallbacks.
  */
 function resolveCcusageCommand(): { cmd: string; args: string[] } {
   if (_resolved) return _resolved;
 
-  // 1. Check if ccusage binary exists on PATH (pure fs, no subprocess)
+  // Check if ccusage binary exists on PATH (pure fs, no subprocess)
   if (isOnPath("ccusage")) {
     _resolved = { cmd: "ccusage", args: [] };
     return _resolved;
   }
 
-  // 2. Prefer bunx if running under Bun
-  if (process.versions.bun !== undefined) {
-    _resolved = { cmd: "bunx", args: ["--bun"] };
-  } else {
-    // 3. Fallback to npx
-    _resolved = { cmd: "npx", args: ["--yes"] };
-  }
-
-  console.error(
-    "Tip: Install ccusage globally for faster syncs: bun add -g ccusage",
+  throw new Error(
+    "ccusage is not installed or not on PATH. Install it globally and retry (e.g. `npm install -g ccusage`).",
   );
-
-  return _resolved;
 }
 
 /** Reset resolver cache — for testing only. */
@@ -75,9 +59,7 @@ export function _resetCcusageResolver(): void {
 /** Run ccusage via the resolved binary. */
 function execCcusage(args: string[], timeoutMs?: number): string {
   const { cmd, args: prefix } = resolveCcusageCommand();
-  // When running via bunx/npx, pin the version to avoid ccusage@18+ runtime: protocol issue
-  const pkg = cmd === "ccusage" ? null : CCUSAGE_PKG;
-  const cmdArgs = pkg ? [...prefix, pkg, ...args] : args;
+  const cmdArgs = [...prefix, ...args];
 
   try {
     return execFileSync(cmd, cmdArgs, {
@@ -90,9 +72,7 @@ function execCcusage(args: string[], timeoutMs?: number): string {
     const error = err as ExecError;
 
     if (error.killed || error.signal === "SIGTERM") {
-      const hint = pkg
-        ? `${cmd} ${prefix.join(" ")} ${pkg} daily --json`
-        : "ccusage daily --json";
+      const hint = `${cmd} ${[...prefix, "daily", "--json"].join(" ")}`;
       throw new Error(
         `ccusage timed out. Try running \`${hint}\` directly to verify it works.`,
       );
@@ -106,8 +86,7 @@ function execCcusage(args: string[], timeoutMs?: number): string {
 /** Async version of execCcusage — runs ccusage in a child process without blocking. */
 function execCcusageAsync(args: string[], timeoutMs?: number): Promise<string> {
   const { cmd, args: prefix } = resolveCcusageCommand();
-  const pkg = cmd === "ccusage" ? null : CCUSAGE_PKG;
-  const cmdArgs = pkg ? [...prefix, pkg, ...args] : args;
+  const cmdArgs = [...prefix, ...args];
 
   return new Promise((resolve, reject) => {
     execFileCb(cmd, cmdArgs, {
@@ -122,9 +101,7 @@ function execCcusageAsync(args: string[], timeoutMs?: number): Promise<string> {
       }
       const error = err as ExecError;
       if (error.killed || error.signal === "SIGTERM") {
-        const hint = pkg
-          ? `${cmd} ${prefix.join(" ")} ${pkg} daily --json`
-          : "ccusage daily --json";
+        const hint = `${cmd} ${[...prefix, "daily", "--json"].join(" ")}`;
         reject(new Error(
           `ccusage timed out. Try running \`${hint}\` directly to verify it works.`,
         ));


### PR DESCRIPTION
### Motivation

- A security scan flagged a supply-chain RCE risk where the CLI could auto-execute `ccusage` via package runners (e.g. `npx --yes ccusage`) in untrusted repos. 
- The change is intended to eliminate auto-install/auto-exec behaviour and ensure only an explicitly installed, trusted `ccusage` binary is executed.

### Description

- Change `resolveCcusageCommand` in `packages/cli/src/lib/ccusage.ts` to only accept an explicitly installed `ccusage` binary on `PATH` and to throw a clear, actionable error if it is not found. 
- Remove the `bunx`/`npx` fallback and the pinned `CCUSAGE_PKG` usage, and update `execCcusage` and `execCcusageAsync` to build command args from the resolved command without injecting package-runner behavior. 
- Update error hints to show the actual command to run (using the resolved `cmd` and args) when timeouts occur. 
- Update tests: `packages/cli/__tests__/ccusage.test.ts` now defaults the `existsSync` mock to simulate `ccusage` being present and changes the fallback test to assert the new "not on PATH" error, and `packages/cli/__tests__/flows/cli-sync-flow.test.ts` was adjusted to treat the `ccusage` PATH lookup as present for integration-style tests.

### Testing

- Ran the CLI test suite with `npm --prefix packages/cli test` and all tests passed (14 test files, 207 tests). 
- The updated tests exercised `runCcusage`, `runCcusageRaw`, and the CLI sync flow integration tests and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbd59c483278bc3574bce6310cd)