### PR TITLE
fix(cli): prevent command injection in login browser open

### DIFF
--- a/packages/cli/__tests__/commands/login.test.ts
+++ b/packages/cli/__tests__/commands/login.test.ts
@@ -19,7 +19,10 @@ vi.mock("../../src/config.js", async (importOriginal) => {
 });
 
 vi.mock("node:child_process", () => ({
-  exec: vi.fn(),
+  spawn: vi.fn(() => ({
+    unref: vi.fn(),
+    on: vi.fn(),
+  })),
 }));
 
 import { loginCommand } from "../../src/commands/login.js";

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { spawn } from "node:child_process";
 import { CONFIG_FILE, DEFAULT_API_URL, POLL_INTERVAL_MS, POLL_TIMEOUT_MS } from "../config.js";
 import { loadConfig, saveConfig } from "../lib/auth.js";
 import { apiRequestNoAuth } from "../lib/api.js";
@@ -15,18 +15,43 @@ interface CliPollResponse {
 }
 
 function openBrowser(url: string): void {
-  const platform = process.platform;
-  let cmd: string;
-  if (platform === "darwin") {
-    cmd = `open "${url}"`;
-  } else if (platform === "win32") {
-    cmd = `start "${url}"`;
-  } else {
-    cmd = `xdg-open "${url}"`;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
   }
-  exec(cmd, () => {
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return;
+  }
+
+  const platform = process.platform;
+  let command: string;
+  let args: string[];
+  if (platform === "darwin") {
+    command = "open";
+    args = [url];
+  } else if (platform === "win32") {
+    command = "rundll32";
+    args = ["url.dll,FileProtocolHandler", url];
+  } else {
+    command = "xdg-open";
+    args = [url];
+  }
+
+  try {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    child.on("error", () => {
+      // ignore errors — user can open the URL manually
+    });
+  } catch {
     // ignore errors — user can open the URL manually
-  });
+  }
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
### Motivation
- The CLI used `exec()` to run platform-specific browser-open commands with a server-provided `verify_url`, creating a command-injection risk when the CLI is pointed at an untrusted API via `--api-url`.
- The goal is to eliminate shell interpolation of an untrusted URL while preserving the UX of opening the browser or printing the URL for manual copy-paste.

### Description
- Replace shell-based `exec()` with `spawn()` and an argument array so the `verify_url` is never interpreted by a shell when launching the browser (`packages/cli/src/commands/login.ts`).
- Add URL parsing and validation in `openBrowser()` to only accept `http:` and `https:` schemes before attempting to open the URL (`packages/cli/src/commands/login.ts`).
- Preserve silent failure behavior (ignore spawn errors and let the user open the printed URL manually) and update unit tests to mock `spawn` instead of `exec` (`packages/cli/__tests__/commands/login.test.ts`).

### Testing
- Ran the login unit tests with `bun --cwd packages/cli test __tests__/commands/login.test.ts` and all tests passed.
- Built the CLI with `bun run --cwd packages/cli build` (runs `tsc`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02bbcf2dc832788dedf4e8bd207be)