### PR TITLE
Harden user feed access control

### DIFF
--- a/apps/web/__tests__/api/feed.test.ts
+++ b/apps/web/__tests__/api/feed.test.ts
@@ -177,14 +177,43 @@ describe("GET /api/feed", () => {
     expect(json.error).toBe("user_id is required for user feed");
   });
 
+  it("falls back to the authenticated user's id for self user feed", async () => {
+    const client = mockSupabase({
+      user: { id: "550e8400-e29b-41d4-a716-446655440000" },
+      profile: { id: "550e8400-e29b-41d4-a716-446655440000", is_public: false },
+      posts: [],
+    });
+
+    const res = await GET(makeRequest({ type: "user" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.posts).toEqual([]);
+    expect(client.rpc).toHaveBeenCalledWith("get_feed", expect.objectContaining({
+      p_type: "user",
+      p_user_id: "550e8400-e29b-41d4-a716-446655440000",
+    }));
+  });
+
+  it("rejects malformed user_id values", async () => {
+    mockSupabase({ user: { id: "user-1" } });
+
+    const res = await GET(makeRequest({ type: "user", user_id: "not-a-uuid" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("user_id must be a valid UUID");
+  });
+
   it("rejects unauthenticated access to a private user feed", async () => {
+    const privateUserId = "550e8400-e29b-41d4-a716-446655440001";
     mockSupabase({
       user: null,
-      profile: { id: "private-user", is_public: false },
+      profile: { id: privateUserId, is_public: false },
     });
 
     const res = await GET(
-      makeRequest({ type: "user", user_id: "private-user" })
+      makeRequest({ type: "user", user_id: privateUserId })
     );
     const json = await res.json();
 
@@ -193,13 +222,14 @@ describe("GET /api/feed", () => {
   });
 
   it("allows follower access to a private user feed", async () => {
+    const privateUserId = "550e8400-e29b-41d4-a716-446655440001";
     mockSupabase({
-      profile: { id: "private-user", is_public: false },
+      profile: { id: privateUserId, is_public: false },
       follow: { id: "follow-1" },
     });
 
     const res = await GET(
-      makeRequest({ type: "user", user_id: "private-user" })
+      makeRequest({ type: "user", user_id: privateUserId })
     );
 
     expect(res.status).toBe(200);

--- a/apps/web/__tests__/api/feed.test.ts
+++ b/apps/web/__tests__/api/feed.test.ts
@@ -4,8 +4,13 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
+vi.mock("@/lib/supabase/service", () => ({
+  getServiceClient: vi.fn(),
+}));
+
 import { GET } from "@/app/api/feed/route";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service";
 import { NextRequest } from "next/server";
 
 function buildChain(terminal: Record<string, any> = {}) {
@@ -29,6 +34,8 @@ function mockSupabase(opts: {
   kudos?: any[];
   userKudos?: any[];
   comments?: any[];
+  profile?: { id: string; is_public: boolean } | null;
+  follow?: { id: string } | null;
 }) {
   const {
     user = { id: "user-1" },
@@ -37,6 +44,8 @@ function mockSupabase(opts: {
     kudos = [],
     userKudos,
     comments = [],
+    profile = null,
+    follow = null,
   } = opts;
 
   const client: Record<string, any> = {
@@ -84,11 +93,44 @@ function mockSupabase(opts: {
           }),
         });
       }
+      if (table === "follows") {
+        return buildChain({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: follow,
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        });
+      }
+      return buildChain();
+    }),
+  };
+
+  const serviceClient: Record<string, any> = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "users") {
+        return buildChain({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: profile,
+                error: null,
+              }),
+            }),
+          }),
+        });
+      }
       return buildChain();
     }),
   };
 
   (createClient as any).mockResolvedValue(client);
+  (getServiceClient as any).mockReturnValue(serviceClient);
   return client;
 }
 
@@ -123,6 +165,44 @@ describe("GET /api/feed", () => {
 
     expect(res.status).toBe(401);
     expect(json.error).toBe("Unauthorized");
+  });
+
+  it("rejects user feed without user_id", async () => {
+    mockSupabase({ user: null });
+
+    const res = await GET(makeRequest({ type: "user" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("user_id is required for user feed");
+  });
+
+  it("rejects unauthenticated access to a private user feed", async () => {
+    mockSupabase({
+      user: null,
+      profile: { id: "private-user", is_public: false },
+    });
+
+    const res = await GET(
+      makeRequest({ type: "user", user_id: "private-user" })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.error).toBe("Forbidden");
+  });
+
+  it("allows follower access to a private user feed", async () => {
+    mockSupabase({
+      profile: { id: "private-user", is_public: false },
+      follow: { id: "follow-1" },
+    });
+
+    const res = await GET(
+      makeRequest({ type: "user", user_id: "private-user" })
+    );
+
+    expect(res.status).toBe(200);
   });
 
   it("returns empty array when user follows nobody", async () => {

--- a/apps/web/app/(app)/u/[username]/page.tsx
+++ b/apps/web/app/(app)/u/[username]/page.tsx
@@ -178,7 +178,7 @@ export default async function ProfilePage({
       .select("daily_usage:daily_usage!posts_daily_usage_id_fkey(date)")
       .eq("user_id", profile.id),
     computeRadarScores(profile.id).catch(() => null),
-    db.rpc("get_feed", {
+    supabase.rpc("get_feed", {
       p_type: "user",
       p_user_id: profile.id,
       p_limit: 20,

--- a/apps/web/app/api/feed/route.ts
+++ b/apps/web/app/api/feed/route.ts
@@ -10,6 +10,9 @@ type KudosRow = {
   user: JoinedUserSummary;
 };
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -44,12 +47,19 @@ export async function GET(request: NextRequest) {
   // pagination continues fetching that user's posts instead of the viewer's.
   const profileUserId = searchParams.get("user_id");
   const effectiveUserId =
-    type === "user" && profileUserId ? profileUserId : (user?.id ?? null);
+    type === "user" ? (profileUserId ?? user?.id ?? null) : (user?.id ?? null);
 
   if (type === "user") {
-    if (!profileUserId) {
+    if (!effectiveUserId) {
       return NextResponse.json(
         { error: "user_id is required for user feed" },
+        { status: 400 },
+      );
+    }
+
+    if (!UUID_PATTERN.test(effectiveUserId)) {
+      return NextResponse.json(
+        { error: "user_id must be a valid UUID" },
         { status: 400 },
       );
     }
@@ -58,18 +68,19 @@ export async function GET(request: NextRequest) {
     const { data: profile, error: profileError } = await db
       .from("users")
       .select("id, is_public")
-      .eq("id", profileUserId)
+      .eq("id", effectiveUserId)
       .maybeSingle();
 
     if (profileError) {
-      return NextResponse.json({ error: profileError.message }, { status: 500 });
+      console.error("[feed] profile lookup error:", profileError);
+      return NextResponse.json({ error: "Unable to load profile" }, { status: 500 });
     }
 
     if (!profile) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    if (!profile.is_public && user?.id !== profileUserId) {
+    if (!profile.is_public && user?.id !== effectiveUserId) {
       if (!user) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
@@ -78,11 +89,12 @@ export async function GET(request: NextRequest) {
         .from("follows")
         .select("id")
         .eq("follower_id", user.id)
-        .eq("following_id", profileUserId)
+        .eq("following_id", effectiveUserId)
         .maybeSingle();
 
       if (followError) {
-        return NextResponse.json({ error: followError.message }, { status: 500 });
+        console.error("[feed] follow lookup error:", followError);
+        return NextResponse.json({ error: "Unable to verify follow status" }, { status: 500 });
       }
 
       if (!follow) {

--- a/apps/web/app/api/feed/route.ts
+++ b/apps/web/app/api/feed/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service";
 import { normalizeCommentPreview, normalizeFeedPost, type JoinedUserSummary, type RawCommentPreviewRow } from "@/lib/feed-normalization";
 import { firstRelation } from "@/lib/utils/first-relation";
 import type { CommentPreviewItem, FeedPostRow, Post, UserSummary } from "@/types";
@@ -44,6 +45,51 @@ export async function GET(request: NextRequest) {
   const profileUserId = searchParams.get("user_id");
   const effectiveUserId =
     type === "user" && profileUserId ? profileUserId : (user?.id ?? null);
+
+  if (type === "user") {
+    if (!profileUserId) {
+      return NextResponse.json(
+        { error: "user_id is required for user feed" },
+        { status: 400 },
+      );
+    }
+
+    const db = getServiceClient();
+    const { data: profile, error: profileError } = await db
+      .from("users")
+      .select("id, is_public")
+      .eq("id", profileUserId)
+      .maybeSingle();
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 });
+    }
+
+    if (!profile) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    if (!profile.is_public && user?.id !== profileUserId) {
+      if (!user) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+
+      const { data: follow, error: followError } = await supabase
+        .from("follows")
+        .select("id")
+        .eq("follower_id", user.id)
+        .eq("following_id", profileUserId)
+        .maybeSingle();
+
+      if (followError) {
+        return NextResponse.json({ error: followError.message }, { status: 500 });
+      }
+
+      if (!follow) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+  }
 
   const { data: rpcPosts, error } = await supabase.rpc("get_feed", {
     p_type: type,

--- a/supabase/migrations/20260413024500_harden_get_feed_user_visibility.sql
+++ b/supabase/migrations/20260413024500_harden_get_feed_user_visibility.sql
@@ -1,0 +1,117 @@
+-- Harden the user feed type so private profile posts are only returned to
+-- authorized viewers. This protects both the app route and direct PostgREST RPC
+-- calls made with the publishable key.
+CREATE OR REPLACE FUNCTION public.get_feed(
+  p_type              text,
+  p_user_id           uuid        DEFAULT NULL,
+  p_limit             int         DEFAULT 20,
+  p_cursor_date       date        DEFAULT NULL,
+  p_cursor_created_at timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  id              uuid,
+  user_id         uuid,
+  daily_usage_id  uuid,
+  title           text,
+  description     text,
+  images          jsonb,
+  created_at      timestamptz,
+  updated_at      timestamptz,
+  "user"          jsonb,
+  daily_usage     jsonb,
+  kudos_count     bigint,
+  comment_count   bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_auth_user_id uuid := auth.uid();
+  v_can_view_user boolean := false;
+BEGIN
+  IF p_type IN ('mine', 'following') THEN
+    IF v_auth_user_id IS NULL OR p_user_id IS NULL OR p_user_id <> v_auth_user_id THEN
+      RAISE EXCEPTION 'Unauthorized'
+        USING ERRCODE = '42501';
+    END IF;
+  ELSIF p_type = 'user' THEN
+    IF p_user_id IS NULL THEN
+      RAISE EXCEPTION 'user_id is required for user feed type'
+        USING ERRCODE = '22023';
+    END IF;
+
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.users u
+      WHERE u.id = p_user_id
+        AND (
+          u.is_public = true
+          OR u.id = v_auth_user_id
+          OR (
+            v_auth_user_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1
+              FROM public.follows f
+              WHERE f.follower_id = v_auth_user_id
+                AND f.following_id = u.id
+            )
+          )
+        )
+    ) INTO v_can_view_user;
+
+    IF NOT v_can_view_user THEN
+      RAISE EXCEPTION 'Forbidden'
+        USING ERRCODE = '42501';
+    END IF;
+  ELSIF p_type <> 'global' THEN
+    RAISE EXCEPTION 'Invalid feed type: %', p_type
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.user_id,
+    p.daily_usage_id,
+    p.title,
+    p.description,
+    p.images,
+    p.created_at,
+    p.updated_at,
+    to_jsonb(u.*) AS "user",
+    to_jsonb(d.*) AS daily_usage,
+    (SELECT COUNT(*) FROM public.kudos k WHERE k.post_id = p.id)   AS kudos_count,
+    (SELECT COUNT(*) FROM public.comments c WHERE c.post_id = p.id) AS comment_count
+  FROM public.posts p
+  JOIN public.users       u ON u.id = p.user_id
+  JOIN public.daily_usage d ON d.id = p.daily_usage_id
+  WHERE
+    CASE p_type
+      WHEN 'global'    THEN u.is_public = true
+      WHEN 'mine'      THEN p.user_id = p_user_id
+      WHEN 'user'      THEN p.user_id = p_user_id
+      WHEN 'following' THEN
+        p.user_id = p_user_id
+        OR EXISTS (
+          SELECT 1 FROM public.follows f
+          WHERE f.follower_id = p_user_id AND f.following_id = p.user_id
+        )
+      ELSE false
+    END
+    AND CASE
+      WHEN p_cursor_date IS NULL AND p_cursor_created_at IS NULL THEN true
+      WHEN p_cursor_date IS NOT NULL THEN
+        d.date < p_cursor_date
+        OR (d.date = p_cursor_date AND p.created_at < p_cursor_created_at)
+      ELSE
+        p.created_at < p_cursor_created_at
+    END
+  ORDER BY d.date DESC, p.created_at DESC
+  LIMIT p_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_feed(text, uuid, int, date, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_feed(text, uuid, int, date, timestamptz) TO anon;


### PR DESCRIPTION
Closes #80.

## What changed
- added a new migration that enforces visibility checks inside `public.get_feed` for `p_type = user
- updated `/api/feed` to reject missing `user_id`s and to return 403/404 before forwarding unauthorized user-feed requests
- switched the profile page user-feed query to the viewer-authenticated Supabase client so follower/private access still works after the RPC is hardened
- added focused feed API tests covering missing `user_id`, private unauthenticated access, and follower access

## Why
The previous implementation trusted callers to do the access control before invoking a `SECURITY DEFINER` RPC. That assumption does not hold for direct API calls or direct PostgREST RPC calls made with the publishable key.

## Validation
- `bun --cwd apps/web test -- __tests__/api/feed.test.ts`
- `bun --cwd apps/web test -- __tests__/flows/privacy-visibility.test.ts`
- `bun --cwd apps/web typecheck` still fails in the baseline on missing `posthog-js` / `posthog-js/react` modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy controls to user feeds: private profiles now require users to be authenticated and follow the profile owner to view content.
  * Improved request validation and error handling: feed requests are now validated for correct format, and users receive appropriate error messages when requests are denied or malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->