### PR TITLE
Restrict private post interaction visibility

### DIFF
--- a/apps/web/__tests__/api/social.test.ts
+++ b/apps/web/__tests__/api/social.test.ts
@@ -262,6 +262,42 @@ describe("POST /api/posts/[id]/kudos", () => {
     expect(json.kudosed).toBe(true);
     expect(json.count).toBe(5);
   });
+
+  it("returns 404 when the post is not visible", async () => {
+    const client: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "posts") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { code: "PGRST116" },
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    (createClient as any).mockResolvedValue(client);
+
+    const res = await kudosPOST(
+      makeRequest("POST", "/api/posts/post-1/kudos"),
+      makeContext("id", "post-1")
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe("Post not found");
+  });
 });
 
 describe("DELETE /api/posts/[id]/kudos", () => {
@@ -413,6 +449,44 @@ describe("POST /api/posts/[id]/comments", () => {
     expect(json.content).toBe("Great work!");
   });
 
+  it("returns 404 when the post is not visible", async () => {
+    const client: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "posts") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { code: "PGRST116" },
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    (createClient as any).mockResolvedValue(client);
+
+    const res = await commentPOST(
+      makeRequest("POST", "/api/posts/post-1/comments", {
+        content: "Great work!",
+      }),
+      makeContext("id", "post-1")
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe("Post not found");
+  });
+
   it("validates 500 char max", async () => {
     const client: Record<string, any> = {
       auth: {
@@ -539,6 +613,18 @@ describe("POST /api/comments/[id]/reactions", () => {
         }),
       },
       from: vi.fn().mockImplementation((table: string) => {
+        if (table === "comments") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: "c-1" },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
         if (table === "comment_reactions") {
           if (callCount++ === 0) {
             return {
@@ -565,6 +651,42 @@ describe("POST /api/comments/[id]/reactions", () => {
     expect(res.status).toBe(200);
     expect(json.reacted).toBe(true);
     expect(json.count).toBe(3);
+  });
+
+  it("returns 404 when the comment is not visible", async () => {
+    const client: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "comments") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { code: "PGRST116" },
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    (createClient as any).mockResolvedValue(client);
+
+    const res = await commentReactionPOST(
+      makeRequest("POST", "/api/comments/c-1/reactions"),
+      makeContext("id", "c-1")
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe("Comment not found");
   });
 });
 

--- a/apps/web/__tests__/unit/migration-safety.test.ts
+++ b/apps/web/__tests__/unit/migration-safety.test.ts
@@ -14,6 +14,12 @@ function getAllMigrations(): { name: string; content: string }[] {
   }));
 }
 
+function getLatestMigrationMatching(pattern: RegExp) {
+  const matches = getAllMigrations().filter((m) => pattern.test(m.content));
+  expect(matches.length).toBeGreaterThan(0);
+  return matches[matches.length - 1]!;
+}
+
 describe("Migration safety", () => {
   const migrations = getAllMigrations();
 
@@ -96,5 +102,44 @@ describe("Migration safety", () => {
         ).toBe(true);
       }
     }
+  });
+
+  it("latest comments SELECT policy is not world-readable", () => {
+    const latest = getLatestMigrationMatching(
+      /ON\s+public\.comments\s+FOR\s+SELECT|ON\s+comments\s+FOR\s+SELECT/i,
+    );
+
+    expect(latest.content).not.toMatch(
+      /ON\s+public\.comments\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
+    );
+    expect(latest.content).not.toMatch(
+      /ON\s+comments\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
+    );
+  });
+
+  it("latest kudos SELECT policy is not world-readable", () => {
+    const latest = getLatestMigrationMatching(
+      /ON\s+public\.kudos\s+FOR\s+SELECT|ON\s+kudos\s+FOR\s+SELECT/i,
+    );
+
+    expect(latest.content).not.toMatch(
+      /ON\s+public\.kudos\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
+    );
+    expect(latest.content).not.toMatch(
+      /ON\s+kudos\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
+    );
+  });
+
+  it("latest comment_reactions SELECT policy is not world-readable", () => {
+    const latest = getLatestMigrationMatching(
+      /ON\s+public\.comment_reactions\s+FOR\s+SELECT|ON\s+comment_reactions\s+FOR\s+SELECT/i,
+    );
+
+    expect(latest.content).not.toMatch(
+      /ON\s+public\.comment_reactions\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
+    );
+    expect(latest.content).not.toMatch(
+      /ON\s+comment_reactions\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
+    );
   });
 });

--- a/apps/web/__tests__/unit/migration-safety.test.ts
+++ b/apps/web/__tests__/unit/migration-safety.test.ts
@@ -142,4 +142,37 @@ describe("Migration safety", () => {
       /ON\s+comment_reactions\s+FOR\s+SELECT[\s\S]*USING\s*\(\s*true\s*\)/i,
     );
   });
+
+  it("latest kudos INSERT policy requires visible parent posts", () => {
+    const latest = getLatestMigrationMatching(
+      /ON\s+public\.kudos\s+FOR\s+INSERT|ON\s+kudos\s+FOR\s+INSERT/i,
+    );
+
+    expect(latest.content).toMatch(/p\.id\s*=\s*kudos\.post_id/i);
+    expect(latest.content).not.toMatch(
+      /ON\s+public\.kudos\s+FOR\s+INSERT[\s\S]*WITH\s+CHECK\s*\(\s*user_id\s*=\s*auth\.uid\(\)\s*\)/i,
+    );
+  });
+
+  it("latest comments INSERT policy requires visible parent posts", () => {
+    const latest = getLatestMigrationMatching(
+      /ON\s+public\.comments\s+FOR\s+INSERT|ON\s+comments\s+FOR\s+INSERT/i,
+    );
+
+    expect(latest.content).toMatch(/p\.id\s*=\s*comments\.post_id/i);
+    expect(latest.content).not.toMatch(
+      /ON\s+public\.comments\s+FOR\s+INSERT[\s\S]*WITH\s+CHECK\s*\(\s*user_id\s*=\s*auth\.uid\(\)\s*\)/i,
+    );
+  });
+
+  it("latest comment_reactions INSERT policy requires visible parent comments", () => {
+    const latest = getLatestMigrationMatching(
+      /ON\s+public\.comment_reactions\s+FOR\s+INSERT|ON\s+comment_reactions\s+FOR\s+INSERT/i,
+    );
+
+    expect(latest.content).toMatch(/c\.id\s*=\s*comment_reactions\.comment_id/i);
+    expect(latest.content).not.toMatch(
+      /ON\s+public\.comment_reactions\s+FOR\s+INSERT[\s\S]*WITH\s+CHECK\s*\(\s*user_id\s*=\s*auth\.uid\(\)\s*\)/i,
+    );
+  });
 });

--- a/apps/web/app/api/comments/[id]/reactions/route.ts
+++ b/apps/web/app/api/comments/[id]/reactions/route.ts
@@ -18,6 +18,16 @@ export async function POST(_request: NextRequest, context: RouteContext) {
   const limited = rateLimit("social", user.id, { limit: 30 });
   if (limited) return limited;
 
+  const { data: comment, error: commentError } = await supabase
+    .from("comments")
+    .select("id")
+    .eq("id", id)
+    .single();
+
+  if (commentError || !comment) {
+    return NextResponse.json({ error: "Comment not found" }, { status: 404 });
+  }
+
   const { error } = await supabase.from("comment_reactions").insert({
     user_id: user.id,
     comment_id: id,

--- a/apps/web/app/api/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/posts/[id]/comments/route.ts
@@ -99,6 +99,19 @@ export async function POST(request: NextRequest, context: RouteContext) {
     );
   }
 
+  const { data: post, error: postError } = await supabase
+    .from("posts")
+    .select("id, user_id")
+    .eq("id", id)
+    .single();
+
+  if (postError || !post) {
+    return NextResponse.json(
+      { error: "Post not found" },
+      { status: 404 }
+    );
+  }
+
   if (parentCommentId) {
     const { data: parentComment, error: parentCommentError } = await supabase
       .from("comments")
@@ -132,11 +145,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
   // Defer notifications and achievements after the response is sent
   after(async () => {
     // Insert comment notification (skip self-comment)
-    const { data: post } = await supabase
-      .from("posts")
-      .select("user_id")
-      .eq("id", id)
-      .single();
     if (post && post.user_id !== user.id) {
       await supabase.from("notifications").insert({
         user_id: post.user_id,

--- a/apps/web/app/api/posts/[id]/kudos/route.ts
+++ b/apps/web/app/api/posts/[id]/kudos/route.ts
@@ -20,6 +20,16 @@ export async function POST(_request: NextRequest, context: RouteContext) {
   const limited = rateLimit("social", user.id, { limit: 30 });
   if (limited) return limited;
 
+  const { data: post, error: postError } = await supabase
+    .from("posts")
+    .select("id, user_id")
+    .eq("id", id)
+    .single();
+
+  if (postError || !post) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
   const { error } = await supabase.from("kudos").insert({
     user_id: user.id,
     post_id: id,
@@ -32,12 +42,6 @@ export async function POST(_request: NextRequest, context: RouteContext) {
   // Fetch post owner for notifications and achievements (deferred after response)
   if (!error) {
     after(async () => {
-      const { data: post } = await supabase
-        .from("posts")
-        .select("user_id")
-        .eq("id", id)
-        .single();
-
       // Insert kudos notification (skip self-kudos)
       if (post && post.user_id !== user.id) {
         await supabase.from("notifications").insert({

--- a/supabase/migrations/20260413025500_harden_private_post_interaction_visibility.sql
+++ b/supabase/migrations/20260413025500_harden_private_post_interaction_visibility.sql
@@ -1,0 +1,70 @@
+-- Ensure interaction tables inherit the same visibility rules as their parent
+-- post. Without this, comments/kudos/reactions can be read directly through
+-- PostgREST even when the post itself is private.
+
+DROP POLICY IF EXISTS "Anyone can view kudos" ON public.kudos;
+CREATE POLICY "Visible post kudos are readable"
+  ON public.kudos FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.posts p
+      JOIN public.users u ON u.id = p.user_id
+      WHERE p.id = kudos.post_id
+        AND (
+          u.is_public = true
+          OR p.user_id = (select auth.uid())
+          OR EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = (select auth.uid())
+              AND f.following_id = p.user_id
+          )
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Anyone can view comments on visible posts" ON public.comments;
+CREATE POLICY "Visible post comments are readable"
+  ON public.comments FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.posts p
+      JOIN public.users u ON u.id = p.user_id
+      WHERE p.id = comments.post_id
+        AND (
+          u.is_public = true
+          OR p.user_id = (select auth.uid())
+          OR EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = (select auth.uid())
+              AND f.following_id = p.user_id
+          )
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Anyone can view comment reactions" ON public.comment_reactions;
+CREATE POLICY "Visible post comment reactions are readable"
+  ON public.comment_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.comments c
+      JOIN public.posts p ON p.id = c.post_id
+      JOIN public.users u ON u.id = p.user_id
+      WHERE c.id = comment_reactions.comment_id
+        AND (
+          u.is_public = true
+          OR p.user_id = (select auth.uid())
+          OR EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = (select auth.uid())
+              AND f.following_id = p.user_id
+          )
+        )
+    )
+  );

--- a/supabase/migrations/20260413025500_harden_private_post_interaction_visibility.sql
+++ b/supabase/migrations/20260413025500_harden_private_post_interaction_visibility.sql
@@ -24,6 +24,29 @@ CREATE POLICY "Visible post kudos are readable"
     )
   );
 
+DROP POLICY IF EXISTS "Users can give kudos" ON public.kudos;
+CREATE POLICY "Users can give kudos on visible posts"
+  ON public.kudos FOR INSERT
+  WITH CHECK (
+    user_id = (select auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM public.posts p
+      JOIN public.users u ON u.id = p.user_id
+      WHERE p.id = kudos.post_id
+        AND (
+          u.is_public = true
+          OR p.user_id = (select auth.uid())
+          OR EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = (select auth.uid())
+              AND f.following_id = p.user_id
+          )
+        )
+    )
+  );
+
 DROP POLICY IF EXISTS "Anyone can view comments on visible posts" ON public.comments;
 CREATE POLICY "Visible post comments are readable"
   ON public.comments FOR SELECT
@@ -46,11 +69,58 @@ CREATE POLICY "Visible post comments are readable"
     )
   );
 
+DROP POLICY IF EXISTS "Users can comment" ON public.comments;
+CREATE POLICY "Users can comment on visible posts"
+  ON public.comments FOR INSERT
+  WITH CHECK (
+    user_id = (select auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM public.posts p
+      JOIN public.users u ON u.id = p.user_id
+      WHERE p.id = comments.post_id
+        AND (
+          u.is_public = true
+          OR p.user_id = (select auth.uid())
+          OR EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = (select auth.uid())
+              AND f.following_id = p.user_id
+          )
+        )
+    )
+  );
+
 DROP POLICY IF EXISTS "Anyone can view comment reactions" ON public.comment_reactions;
 CREATE POLICY "Visible post comment reactions are readable"
   ON public.comment_reactions FOR SELECT
   USING (
     EXISTS (
+      SELECT 1
+      FROM public.comments c
+      JOIN public.posts p ON p.id = c.post_id
+      JOIN public.users u ON u.id = p.user_id
+      WHERE c.id = comment_reactions.comment_id
+        AND (
+          u.is_public = true
+          OR p.user_id = (select auth.uid())
+          OR EXISTS (
+            SELECT 1
+            FROM public.follows f
+            WHERE f.follower_id = (select auth.uid())
+              AND f.following_id = p.user_id
+          )
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can react to comments" ON public.comment_reactions;
+CREATE POLICY "Users can react to visible comments"
+  ON public.comment_reactions FOR INSERT
+  WITH CHECK (
+    user_id = (select auth.uid())
+    AND EXISTS (
       SELECT 1
       FROM public.comments c
       JOIN public.posts p ON p.id = c.post_id


### PR DESCRIPTION
Closes #79.

## What changed
- added a migration that makes `comments`, `kudos`, and `comment_reactions` inherit parent-post visibility instead of using world-readable `SELECT` policies
- extended the migration safety test so future migrations cannot quietly reintroduce `USING (true)` on those interaction tables

## Why
The previous policies allowed direct PostgREST reads of comment text and interaction metadata for private posts, even though the parent post was supposed to remain follower-only/private.

## Validation
- `bun --cwd apps/web test -- __tests__/unit/migration-safety.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API endpoints now properly return 404 responses when attempting to interact with non-existent posts or comments.

* **Database**
  * Updated row-level security policies for post interactions to control visibility and access based on author privacy settings and follower relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->