### PR TITLE
Lock DM attachments to sender ownership

### DIFF
--- a/apps/web/__tests__/api/messages.test.ts
+++ b/apps/web/__tests__/api/messages.test.ts
@@ -389,6 +389,38 @@ describe("POST /api/messages", () => {
     expect(response.status).toBe(400);
     expect(json.error).toContain("Straude-managed DM storage uploads");
   });
+
+  it("rejects attachment paths owned by another user", async () => {
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+    };
+
+    (createClient as any).mockResolvedValue(authClient);
+
+    const response = await messagePOST(
+      makeRequest("POST", "/api/messages", {
+        recipientUsername: "alice",
+        attachments: [
+          {
+            bucket: "dm-attachments",
+            path: "user-2/file.png",
+            name: "file.png",
+            type: "image/png",
+            size: 123,
+          },
+        ],
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("Attachments must belong to the sending user");
+  });
 });
 
 describe("message attachments", () => {
@@ -495,6 +527,113 @@ describe("message attachments", () => {
 
     expect(response.status).toBe(200);
     expect(json.messages[0].attachments[0].url).toContain("/storage/v1/object/sign/dm-attachments/");
+  });
+
+  it("does not sign attachments that do not belong to the message sender", async () => {
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+    };
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://example.supabase.co/storage/v1/object/sign/dm-attachments/user-2/file.png?token=abc" },
+      error: null,
+    });
+    const serviceClient: Record<string, any> = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "users") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockImplementation((field: string, value: string) => {
+                if (field === "username" && value === "alice") {
+                  return {
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: {
+                        id: "user-2",
+                        username: "alice",
+                        avatar_url: null,
+                        display_name: "Alice",
+                        is_public: true,
+                      },
+                      error: null,
+                    }),
+                  };
+                }
+                if (field === "id" && value === "user-1") {
+                  return {
+                    single: vi.fn().mockResolvedValue({
+                      data: {
+                        id: "user-1",
+                        username: "bob",
+                        avatar_url: null,
+                        display_name: "Bob",
+                      },
+                      error: null,
+                    }),
+                  };
+                }
+                throw new Error(`Unexpected users lookup ${field}:${value}`);
+              }),
+            }),
+          };
+        }
+
+        if (table === "direct_messages") {
+          return {
+            select: vi.fn().mockReturnValue({
+              or: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({
+                    data: [
+                      {
+                        id: "m-2",
+                        sender_id: "user-2",
+                        recipient_id: "user-1",
+                        content: null,
+                        attachments: [
+                          {
+                            bucket: "dm-attachments",
+                            path: "user-3/file.png",
+                            name: "file.png",
+                            type: "image/png",
+                            size: 123,
+                          },
+                        ],
+                        read_at: null,
+                        created_at: "2026-03-06T12:00:00.000Z",
+                      },
+                    ],
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+
+        throw new Error(`Unexpected table ${table}`);
+      }),
+      storage: {
+        from: vi.fn().mockReturnValue({
+          createSignedUrl,
+        }),
+      },
+    };
+
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(serviceClient);
+
+    const response = await conversationGET(
+      makeRequest("GET", "/api/messages?with=alice")
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.messages[0].attachments).toEqual([]);
+    expect(createSignedUrl).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/__tests__/unit/migration-safety.test.ts
+++ b/apps/web/__tests__/unit/migration-safety.test.ts
@@ -97,4 +97,23 @@ describe("Migration safety", () => {
       }
     }
   });
+
+  it("latest DM attachment hardening limits updates to read_at and validates paths", () => {
+    const dmAttachmentMigrations = migrations.filter((m) =>
+      /direct_messages/i.test(m.content)
+      && /dm-attachments/i.test(m.content)
+    );
+
+    expect(dmAttachmentMigrations.length).toBeGreaterThan(0);
+
+    const latest = dmAttachmentMigrations[dmAttachmentMigrations.length - 1];
+
+    expect(
+      /GRANT\s+UPDATE\s*\(\s*read_at\s*\)\s+ON\s+public\.direct_messages\s+TO\s+authenticated/i.test(
+        latest.content
+      )
+    ).toBe(true);
+    expect(/left\(attachment->>'path',\s*1\)\s*=\s*'\/'/i.test(latest.content)).toBe(true);
+    expect(/position\('\.\.'\s+IN\s+attachment->>'path'\)\s*>\s*0/i.test(latest.content)).toBe(true);
+  });
 });

--- a/apps/web/app/api/messages/route.ts
+++ b/apps/web/app/api/messages/route.ts
@@ -2,7 +2,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import { after } from "@/lib/utils/after";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
-import { normalizeMessageAttachmentInput } from "@/lib/storage";
+import {
+  isStoragePathOwnedByUser,
+  normalizeMessageAttachmentInput,
+} from "@/lib/storage";
 import { sendDirectMessageEmail } from "@/lib/email/send-direct-message-email";
 import { rateLimit } from "@/lib/rate-limit";
 import type { MessageAttachment, MessageAttachmentInput } from "@/types";
@@ -104,12 +107,18 @@ async function fireDirectMessageNotificationEmail(opts: {
 
 async function buildSignedAttachments(
   rawAttachments: unknown,
+  expectedOwnerId?: string,
 ): Promise<MessageAttachment[]> {
   const db = getServiceClient();
   const attachments = Array.isArray(rawAttachments)
     ? rawAttachments
         .map(normalizeMessageAttachmentInput)
-        .filter((attachment): attachment is MessageAttachmentInput => attachment !== null)
+        .filter((attachment): attachment is MessageAttachmentInput => {
+          if (attachment === null) return false;
+          return expectedOwnerId
+            ? isStoragePathOwnedByUser(attachment.path, expectedOwnerId)
+            : true;
+        })
     : [];
 
   if (attachments.length === 0) {
@@ -196,7 +205,10 @@ export async function GET(request: NextRequest) {
   const messages = await Promise.all(
     [...(messagesRes.data ?? [])].reverse().map(async (message) => ({
       ...message,
-      attachments: await buildSignedAttachments(message.attachments),
+      attachments: await buildSignedAttachments(
+        message.attachments,
+        message.sender_id,
+      ),
       sender: message.sender_id === user.id ? selfProfile : counterpart,
       recipient: message.sender_id === user.id ? counterpart : selfProfile,
     })),
@@ -246,6 +258,13 @@ export async function POST(request: NextRequest) {
   if (Array.isArray(rawAttachments) && attachments.length !== rawAttachments.length) {
     return NextResponse.json(
       { error: "Attachments must use Straude-managed DM storage uploads" },
+      { status: 400 },
+    );
+  }
+
+  if (attachments.some((attachment) => !isStoragePathOwnedByUser(attachment.path, user.id))) {
+    return NextResponse.json(
+      { error: "Attachments must belong to the sending user" },
       { status: 400 },
     );
   }
@@ -300,7 +319,10 @@ export async function POST(request: NextRequest) {
   }
 
   const sender = senderRes.data as ConversationUser;
-  const signedAttachments = await buildSignedAttachments(messageRes.data.attachments);
+  const signedAttachments = await buildSignedAttachments(
+    messageRes.data.attachments,
+    user.id,
+  );
   const message = {
     ...messageRes.data,
     attachments: signedAttachments,

--- a/apps/web/lib/storage.ts
+++ b/apps/web/lib/storage.ts
@@ -26,6 +26,10 @@ function isValidStoragePath(path: string) {
   return path.length > 0 && !path.startsWith("/") && !path.includes("..");
 }
 
+export function isStoragePathOwnedByUser(path: string, userId: string): boolean {
+  return isValidStoragePath(path) && path.startsWith(`${userId}/`);
+}
+
 export function extractPublicStoragePath(
   url: string,
   bucket: StorageBucket,

--- a/supabase/migrations/20260413030500_harden_direct_message_attachment_ownership.sql
+++ b/supabase/migrations/20260413030500_harden_direct_message_attachment_ownership.sql
@@ -1,6 +1,9 @@
 -- Prevent users from referencing another user's DM attachment path when
 -- inserting a direct message through PostgREST.
 
+REVOKE UPDATE ON public.direct_messages FROM authenticated;
+GRANT UPDATE (read_at) ON public.direct_messages TO authenticated;
+
 DROP POLICY IF EXISTS "Users can send direct messages" ON public.direct_messages;
 CREATE POLICY "Users can send direct messages"
   ON public.direct_messages FOR INSERT
@@ -33,6 +36,8 @@ CREATE POLICY "Users can send direct messages"
       WHERE jsonb_typeof(attachment) <> 'object'
         OR attachment->>'bucket' <> 'dm-attachments'
         OR NULLIF(attachment->>'path', '') IS NULL
+        OR left(attachment->>'path', 1) = '/'
+        OR position('..' IN attachment->>'path') > 0
         OR split_part(attachment->>'path', '/', 1) <> auth.uid()::text
     )
   );

--- a/supabase/migrations/20260413030500_harden_direct_message_attachment_ownership.sql
+++ b/supabase/migrations/20260413030500_harden_direct_message_attachment_ownership.sql
@@ -1,0 +1,38 @@
+-- Prevent users from referencing another user's DM attachment path when
+-- inserting a direct message through PostgREST.
+
+DROP POLICY IF EXISTS "Users can send direct messages" ON public.direct_messages;
+CREATE POLICY "Users can send direct messages"
+  ON public.direct_messages FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = sender_id
+    AND EXISTS (
+      SELECT 1
+      FROM public.users recipient
+      WHERE recipient.id = recipient_id
+        AND (
+          recipient.is_public
+          OR EXISTS (
+            SELECT 1
+            FROM public.direct_messages dm
+            WHERE (
+              dm.sender_id = sender_id
+              AND dm.recipient_id = recipient_id
+            )
+            OR (
+              dm.sender_id = recipient_id
+              AND dm.recipient_id = sender_id
+            )
+          )
+        )
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(COALESCE(attachments, '[]'::jsonb)) AS attachment
+      WHERE jsonb_typeof(attachment) <> 'object'
+        OR attachment->>'bucket' <> 'dm-attachments'
+        OR NULLIF(attachment->>'path', '') IS NULL
+        OR split_part(attachment->>'path', '/', 1) <> auth.uid()::text
+    )
+  );


### PR DESCRIPTION
Closes #81.

## What changed
- added a migration that prevents `direct_messages` inserts from referencing `dm-attachments` paths outside the sender namespace
- added app-side validation so `/api/messages` rejects foreign attachment paths immediately
- hardened signed URL generation so legacy/bad rows no longer produce attachment URLs when the stored path does not belong to the message sender
- added API tests covering both the POST rejection path and the GET signing guard

## Why
Attachment paths were effectively transferable capabilities. Once a participant learned a path from one conversation, they could reference it in another message and cause the app to mint a fresh signed URL for a new recipient.

## Validation
- `bun --cwd apps/web test -- __tests__/api/messages.test.ts`
