### PR TITLE
Restrict public user metadata exposure

### DIFF
--- a/apps/web/__tests__/api/profile.test.ts
+++ b/apps/web/__tests__/api/profile.test.ts
@@ -45,6 +45,7 @@ describe("GET /api/users/[username]", () => {
       username: "alice",
       is_public: true,
       region: "north_america",
+      streak_freezes: 2,
     };
 
     const client: Record<string, any> = {
@@ -169,6 +170,9 @@ describe("GET /api/users/[username]", () => {
     expect(json.streak).toBe(7);
     expect(json.total_cost).toBe(15);
     expect(json.level).toBe(4);
+    expect(json.streak_freezes).toBeUndefined();
+    expect(json.referred_by).toBeUndefined();
+    expect(json.created_at).toBeUndefined();
   });
 
   it("returns 404 for non-existent username", async () => {

--- a/apps/web/__tests__/api/profile.test.ts
+++ b/apps/web/__tests__/api/profile.test.ts
@@ -16,8 +16,8 @@ vi.mock("@/lib/constants/regions", () => ({
   },
 }));
 
-import { GET } from "@/app/api/users/[username]/route";
-import { PATCH } from "@/app/api/users/me/route";
+import { GET as getPublicProfile } from "@/app/api/users/[username]/route";
+import { GET as getOwnProfile, PATCH } from "@/app/api/users/me/route";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { NextRequest } from "next/server";
@@ -158,7 +158,7 @@ describe("GET /api/users/[username]", () => {
     });
     (getServiceClient as any).mockReturnValue(client);
 
-    const res = await GET(
+    const res = await getPublicProfile(
       makeRequest("GET", "/api/users/alice"),
       makeContext("alice")
     );
@@ -213,7 +213,7 @@ describe("GET /api/users/[username]", () => {
       }),
     });
 
-    const res = await GET(
+    const res = await getPublicProfile(
       makeRequest("GET", "/api/users/nobody"),
       makeContext("nobody")
     );
@@ -221,6 +221,52 @@ describe("GET /api/users/[username]", () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toBe("User not found");
+  });
+});
+
+describe("GET /api/users/me", () => {
+  it("returns the authenticated profile with crew count", async () => {
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "u-1" } },
+          error: null,
+        }),
+      },
+    };
+
+    const db = {
+      from: vi
+        .fn()
+        .mockImplementationOnce(() => ({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "u-1", username: "alice", github_username: "alicegh" },
+                error: null,
+              }),
+            }),
+          }),
+        }))
+        .mockImplementationOnce(() => ({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              count: 3,
+              error: null,
+            }),
+          }),
+        })),
+    };
+
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
+
+    const res = await getOwnProfile();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.username).toBe("alice");
+    expect(json.crew_count).toBe(3);
   });
 });
 
@@ -233,13 +279,15 @@ describe("PATCH /api/users/me", () => {
       heard_about: "A friend mentioned it",
     };
 
-    const client: Record<string, any> = {
+    const authClient: Record<string, any> = {
       auth: {
         getUser: vi.fn().mockResolvedValue({
           data: { user: { id: "u-1" } },
           error: null,
         }),
       },
+    };
+    const db = {
       from: vi.fn().mockReturnValue({
         update: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
@@ -253,7 +301,8 @@ describe("PATCH /api/users/me", () => {
         }),
       }),
     };
-    (createClient as any).mockResolvedValue(client);
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
 
     const res = await PATCH(
       makeRequest("PATCH", "/api/users/me", {
@@ -360,16 +409,19 @@ describe("PATCH /api/users/me", () => {
       }),
     });
 
-    const client: Record<string, any> = {
+    const authClient: Record<string, any> = {
       auth: {
         getUser: vi.fn().mockResolvedValue({
           data: { user: { id: "u-1" } },
           error: null,
         }),
       },
+    };
+    const db = {
       from: vi.fn().mockReturnValue({ update: updateMock }),
     };
-    (createClient as any).mockResolvedValue(client);
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
 
     await PATCH(
       makeRequest("PATCH", "/api/users/me", { country: "US" })
@@ -384,13 +436,15 @@ describe("PATCH /api/users/me", () => {
   });
 
   it("rejects duplicate username (409)", async () => {
-    const client: Record<string, any> = {
+    const authClient: Record<string, any> = {
       auth: {
         getUser: vi.fn().mockResolvedValue({
           data: { user: { id: "u-1" } },
           error: null,
         }),
       },
+    };
+    const db = {
       from: vi.fn().mockReturnValue({
         update: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
@@ -404,7 +458,8 @@ describe("PATCH /api/users/me", () => {
         }),
       }),
     };
-    (createClient as any).mockResolvedValue(client);
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
 
     const res = await PATCH(
       makeRequest("PATCH", "/api/users/me", { username: "taken_name" })

--- a/apps/web/__tests__/flows/privacy-visibility.test.ts
+++ b/apps/web/__tests__/flows/privacy-visibility.test.ts
@@ -233,7 +233,7 @@ describe("Flow: Privacy and Visibility", () => {
     (updateChain.select as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
     (updateChain.eq as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
 
-    mockSupabase.from.mockImplementation(() => updateChain);
+    mockServiceClient.from.mockImplementation(() => updateChain);
 
     const { PATCH } = await import("@/app/api/users/me/route");
     const req = makeRequest("http://localhost:3000/api/users/me", {

--- a/apps/web/__tests__/flows/profile-and-contributions.test.ts
+++ b/apps/web/__tests__/flows/profile-and-contributions.test.ts
@@ -78,7 +78,7 @@ describe("Flow: Profile and Contributions", () => {
     (updateChain.select as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
     (updateChain.eq as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
 
-    mockSupabase.from.mockImplementation(() => updateChain);
+    mockServiceClient.from.mockImplementation(() => updateChain);
 
     const { PATCH } = await import("@/app/api/users/me/route");
     const req = makeRequest("http://localhost:3000/api/users/me", {

--- a/apps/web/__tests__/flows/signup-to-feed.test.ts
+++ b/apps/web/__tests__/flows/signup-to-feed.test.ts
@@ -127,7 +127,7 @@ describe("Flow: Signup to Feed", () => {
     (updateChain.select as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
     (updateChain.eq as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
 
-    mockSupabase.from.mockImplementation((table: string) => {
+    mockServiceSupabase.from.mockImplementation((table: string) => {
       if (table === "users") return updateChain;
       return chainBuilder();
     });

--- a/apps/web/__tests__/unit/migration-safety.test.ts
+++ b/apps/web/__tests__/unit/migration-safety.test.ts
@@ -97,4 +97,44 @@ describe("Migration safety", () => {
       }
     }
   });
+
+  it("latest public.users grants only expose a sanitized select list", () => {
+    const usersGrantMigrations = migrations.filter((m) =>
+      /public\.users/i.test(m.content)
+      && (
+        /REVOKE\s+ALL\s+ON\s+public\.users/i.test(m.content)
+        || /GRANT\s+SELECT\s+ON\s+public\.users/i.test(m.content)
+        || /GRANT\s+SELECT\s*\(/i.test(m.content)
+      )
+    );
+
+    expect(usersGrantMigrations.length).toBeGreaterThan(0);
+
+    const latest = usersGrantMigrations[usersGrantMigrations.length - 1];
+
+    expect(
+      /GRANT\s+SELECT\s+ON\s+public\.users\s+TO\s+anon/i.test(latest.content)
+    ).toBe(false);
+    expect(
+      /GRANT\s+SELECT\s+ON\s+public\.users\s+TO\s+authenticated/i.test(latest.content)
+    ).toBe(false);
+    expect(
+      /GRANT\s+SELECT\s*\([^)]*github_username[^)]*\)\s+ON\s+public\.users\s+TO\s+anon/i.test(
+        latest.content
+      )
+    ).toBe(true);
+  });
+
+  it("latest get_feed() definition redacts joined user columns", () => {
+    const redefining = migrations.filter((m) =>
+      /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.get_feed/i.test(m.content)
+    );
+
+    expect(redefining.length).toBeGreaterThan(0);
+
+    const latest = redefining[redefining.length - 1];
+
+    expect(/to_jsonb\(u\.\*\)/i.test(latest.content)).toBe(false);
+    expect(/jsonb_build_object\s*\(/i.test(latest.content)).toBe(true);
+  });
 });

--- a/apps/web/app/(app)/card/page.tsx
+++ b/apps/web/app/(app)/card/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/Button";
 import { Copy, Check, ExternalLink } from "lucide-react";
 import Link from "next/link";
@@ -55,17 +54,13 @@ export default function CardPage() {
 
   useEffect(() => {
     async function load() {
-      const supabase = createClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) return;
+      const res = await fetch("/api/users/me");
+      if (!res.ok) {
+        setLoading(false);
+        return;
+      }
 
-      const { data: profile } = await supabase
-        .from("users")
-        .select("username, is_public")
-        .eq("id", user.id)
-        .single();
+      const profile = await res.json();
 
       if (profile?.username) {
         setUsername(profile.username);

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service";
 import { getAuthUser } from "@/lib/supabase/auth";
 import { Sidebar } from "@/components/app/shared/Sidebar";
 import { RightSidebar } from "@/components/app/shared/RightSidebar";
@@ -30,6 +31,7 @@ export default async function AppLayout({
 }) {
   const user = await getAuthUser();
   const supabase = await createClient();
+  const db = getServiceClient();
 
   // If not logged in: allow public pages, redirect others to login
   if (!user) {
@@ -60,7 +62,7 @@ export default async function AppLayout({
     usageTotalsRes,
     photoAchievementRes,
   ] = await Promise.all([
-    supabase
+    db
       .from("users")
       .select("*")
       .eq("id", user.id)

--- a/apps/web/app/(app)/post/[id]/page.tsx
+++ b/apps/web/app/(app)/post/[id]/page.tsx
@@ -118,7 +118,7 @@ export default async function PostDetailPage({
     .select(
       `
       *,
-      user:users!posts_user_id_fkey(*),
+      user:users!posts_user_id_fkey(id, username, display_name, bio, avatar_url, country, region, link, github_username, is_public),
       daily_usage:daily_usage!posts_daily_usage_id_fkey(*),
       kudos_count:kudos(count),
       comment_count:comments(count)

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -17,6 +17,7 @@ import { CountryPicker } from "@/components/ui/CountryPicker";
 export default function SettingsPage() {
   const router = useRouter();
   const [profile, setProfile] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,18 +46,13 @@ export default function SettingsPage() {
 
   useEffect(() => {
     async function load() {
-      const supabase = createClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) return;
+      const res = await fetch("/api/users/me");
+      if (!res.ok) {
+        setLoading(false);
+        return;
+      }
 
-      const { data } = await supabase
-        .from("users")
-        .select("*")
-        .eq("id", user.id)
-        .single();
-
+      const data = await res.json();
       if (data) {
         setProfile(data);
         setUsername(data.username ?? "");
@@ -71,14 +67,9 @@ export default function SettingsPage() {
         setEmailMentionNotifications(data.email_mention_notifications ?? true);
         setEmailDmNotifications(data.email_dm_notifications ?? true);
         setTimezone(data.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone);
-
-        // Fetch crew count
-        const { count } = await supabase
-          .from("users")
-          .select("id", { count: "exact", head: true })
-          .eq("referred_by", data.id);
-        setCrewCount(count ?? 0);
+        setCrewCount(data.crew_count ?? 0);
       }
+      setLoading(false);
     }
     load();
   }, []);
@@ -161,8 +152,12 @@ export default function SettingsPage() {
     setSaving(false);
   }
 
-  if (!profile) {
+  if (loading) {
     return <div className="px-[var(--app-page-padding-x)] py-6 text-sm text-muted">Loading&hellip;</div>;
+  }
+
+  if (!profile) {
+    return <div className="px-[var(--app-page-padding-x)] py-6 text-sm text-muted">Unable to load profile.</div>;
   }
 
   return (

--- a/apps/web/app/(app)/u/[username]/page.tsx
+++ b/apps/web/app/(app)/u/[username]/page.tsx
@@ -178,7 +178,7 @@ export default async function ProfilePage({
       .select("daily_usage:daily_usage!posts_daily_usage_id_fkey(date)")
       .eq("user_id", profile.id),
     computeRadarScores(profile.id).catch(() => null),
-    db.rpc("get_feed", {
+    supabase.rpc("get_feed", {
       p_type: "user",
       p_user_id: profile.id,
       p_limit: 20,

--- a/apps/web/app/(auth)/callback/route.ts
+++ b/apps/web/app/(auth)/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service";
 
 export async function GET(request: Request) {
   const { searchParams, origin: requestOrigin } = new URL(request.url);
@@ -19,7 +20,8 @@ export async function GET(request: Request) {
         data: { user },
       } = await supabase.auth.getUser();
       if (user) {
-        const { data: profile } = await supabase
+        const db = getServiceClient();
+        const { data: profile } = await db
           .from("users")
           .select("username, github_username, onboarding_completed")
           .eq("id", user.id)
@@ -33,7 +35,7 @@ export async function GET(request: Request) {
             .slice(0, 20);
           if (/^[a-zA-Z0-9_]{3,20}$/.test(sanitized)) {
             // Best-effort: if taken, onboarding will handle it
-            await supabase
+            await db
               .from("users")
               .update({ username: sanitized })
               .eq("id", user.id);

--- a/apps/web/app/(onboarding)/layout.tsx
+++ b/apps/web/app/(onboarding)/layout.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 
@@ -20,8 +21,10 @@ export default async function OnboardingLayout({
     redirect("/login");
   }
 
+  const db = getServiceClient();
+
   // Already onboarded — send to feed
-  const { data: profile } = await supabase
+  const { data: profile } = await db
     .from("users")
     .select("username, onboarding_completed")
     .eq("id", user.id)

--- a/apps/web/app/api/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/posts/[id]/comments/route.ts
@@ -122,7 +122,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       content,
       parent_comment_id: parentCommentId,
     })
-    .select("*, user:users!comments_user_id_fkey(*)")
+    .select("*, user:users!comments_user_id_fkey(id, username, display_name, bio, avatar_url, is_public)")
     .single();
 
   if (error) {

--- a/apps/web/app/api/posts/[id]/kudos/route.ts
+++ b/apps/web/app/api/posts/[id]/kudos/route.ts
@@ -99,7 +99,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
   let query = supabase
     .from("kudos")
-    .select("*, user:users!kudos_user_id_fkey(*)")
+    .select("*, user:users!kudos_user_id_fkey(id, username, display_name, bio, avatar_url, is_public)")
     .eq("post_id", id)
     .order("created_at", { ascending: false })
     .limit(limit);

--- a/apps/web/app/api/posts/[id]/route.ts
+++ b/apps/web/app/api/posts/[id]/route.ts
@@ -22,7 +22,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     .select(
       `
       *,
-      user:users!posts_user_id_fkey(*),
+      user:users!posts_user_id_fkey(id, username, display_name, bio, avatar_url, country, region, link, github_username, is_public),
       daily_usage:daily_usage!posts_daily_usage_id_fkey(*),
       kudos_count:kudos(count),
       comment_count:comments(count)

--- a/apps/web/app/api/users/[username]/route.ts
+++ b/apps/web/app/api/users/[username]/route.ts
@@ -15,8 +15,6 @@ type PublicProfileRow = {
   github_username: string | null;
   is_public: boolean;
   streak_freezes: number | null;
-  referred_by: string | null;
-  created_at: string;
 };
 type TotalCostAggregateRow = {
   cost_usd: number | string | null;
@@ -26,7 +24,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { username } = await context.params;
   const access = await getProfileAccessContext<PublicProfileRow>(
     username,
-    "id, username, display_name, avatar_url, bio, country, region, link, github_username, is_public, streak_freezes, referred_by, created_at",
+    "id, username, display_name, avatar_url, bio, country, region, link, github_username, is_public, streak_freezes",
   );
 
   if (!access) {
@@ -117,7 +115,16 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   }
 
   return NextResponse.json({
-    ...profile,
+    id: profile.id,
+    username: profile.username,
+    display_name: profile.display_name,
+    avatar_url: profile.avatar_url,
+    bio: profile.bio,
+    country: profile.country,
+    region: profile.region,
+    link: profile.link,
+    github_username: profile.github_username,
+    is_public: profile.is_public,
     followers_count: followersRes.count ?? 0,
     following_count: followingRes.count ?? 0,
     posts_count: postsRes.count ?? 0,

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -35,17 +35,27 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: profile, error } = await supabase
-    .from("users")
-    .select("*")
-    .eq("id", user.id)
-    .single();
+  const db = getServiceClient();
+  const [{ data: profile, error }, { count: crewCount }] = await Promise.all([
+    db
+      .from("users")
+      .select("*")
+      .eq("id", user.id)
+      .single(),
+    db
+      .from("users")
+      .select("id", { count: "exact", head: true })
+      .eq("referred_by", user.id),
+  ]);
 
   if (error || !profile) {
     return NextResponse.json({ error: "Profile not found" }, { status: 404 });
   }
 
-  return NextResponse.json(profile);
+  return NextResponse.json({
+    ...profile,
+    crew_count: crewCount ?? 0,
+  });
 }
 
 export async function PATCH(request: NextRequest) {
@@ -131,7 +141,8 @@ export async function PATCH(request: NextRequest) {
 
   const isOnboardingUpdate = updates.onboarding_completed === true;
 
-  const { data: profile, error } = await supabase
+  const db = getServiceClient();
+  const { data: profile, error } = await db
     .from("users")
     .update(updates)
     .eq("id", user.id)

--- a/apps/web/lib/comments.ts
+++ b/apps/web/lib/comments.ts
@@ -17,7 +17,7 @@ export async function loadPostComments(opts: {
 
   let query = opts.supabase
     .from("comments")
-    .select("*, user:users!comments_user_id_fkey(*)")
+    .select("*, user:users!comments_user_id_fkey(id, username, display_name, bio, avatar_url, is_public)")
     .eq("post_id", opts.postId)
     .order("created_at", { ascending: true })
     .limit(limit);

--- a/supabase/migrations/20260413034500_harden_users_public_columns.sql
+++ b/supabase/migrations/20260413034500_harden_users_public_columns.sql
@@ -1,0 +1,158 @@
+-- Restrict publishable-key reads from public.users to a sanitized public
+-- profile subset, and ensure get_feed returns the same redacted user shape
+-- even though it runs as SECURITY DEFINER.
+
+REVOKE ALL ON public.users FROM anon;
+GRANT SELECT (
+  id,
+  username,
+  display_name,
+  bio,
+  avatar_url,
+  country,
+  region,
+  link,
+  github_username,
+  is_public
+) ON public.users TO anon;
+
+REVOKE ALL ON public.users FROM authenticated;
+GRANT UPDATE ON public.users TO authenticated;
+GRANT SELECT (
+  id,
+  username,
+  display_name,
+  bio,
+  avatar_url,
+  country,
+  region,
+  link,
+  github_username,
+  is_public
+) ON public.users TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_feed(
+  p_type              text,
+  p_user_id           uuid        DEFAULT NULL,
+  p_limit             int         DEFAULT 20,
+  p_cursor_date       date        DEFAULT NULL,
+  p_cursor_created_at timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  id              uuid,
+  user_id         uuid,
+  daily_usage_id  uuid,
+  title           text,
+  description     text,
+  images          jsonb,
+  created_at      timestamptz,
+  updated_at      timestamptz,
+  "user"          jsonb,
+  daily_usage     jsonb,
+  kudos_count     bigint,
+  comment_count   bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_auth_user_id uuid := auth.uid();
+  v_can_view_user boolean := false;
+BEGIN
+  IF p_type IN ('mine', 'following') THEN
+    IF v_auth_user_id IS NULL OR p_user_id IS NULL OR p_user_id <> v_auth_user_id THEN
+      RAISE EXCEPTION 'Unauthorized'
+        USING ERRCODE = '42501';
+    END IF;
+  ELSIF p_type = 'user' THEN
+    IF p_user_id IS NULL THEN
+      RAISE EXCEPTION 'user_id is required for user feed type'
+        USING ERRCODE = '22023';
+    END IF;
+
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.users u
+      WHERE u.id = p_user_id
+        AND (
+          u.is_public = true
+          OR u.id = v_auth_user_id
+          OR (
+            v_auth_user_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1
+              FROM public.follows f
+              WHERE f.follower_id = v_auth_user_id
+                AND f.following_id = u.id
+            )
+          )
+        )
+    ) INTO v_can_view_user;
+
+    IF NOT v_can_view_user THEN
+      RAISE EXCEPTION 'Forbidden'
+        USING ERRCODE = '42501';
+    END IF;
+  ELSIF p_type <> 'global' THEN
+    RAISE EXCEPTION 'Invalid feed type: %', p_type
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.user_id,
+    p.daily_usage_id,
+    p.title,
+    p.description,
+    p.images,
+    p.created_at,
+    p.updated_at,
+    jsonb_build_object(
+      'id', u.id,
+      'username', u.username,
+      'display_name', u.display_name,
+      'bio', u.bio,
+      'avatar_url', u.avatar_url,
+      'country', u.country,
+      'region', u.region,
+      'link', u.link,
+      'github_username', u.github_username,
+      'is_public', u.is_public
+    ) AS "user",
+    to_jsonb(d.*) AS daily_usage,
+    (SELECT COUNT(*) FROM public.kudos k WHERE k.post_id = p.id)   AS kudos_count,
+    (SELECT COUNT(*) FROM public.comments c WHERE c.post_id = p.id) AS comment_count
+  FROM public.posts p
+  JOIN public.users       u ON u.id = p.user_id
+  JOIN public.daily_usage d ON d.id = p.daily_usage_id
+  WHERE
+    CASE p_type
+      WHEN 'global'    THEN u.is_public = true
+      WHEN 'mine'      THEN p.user_id = p_user_id
+      WHEN 'user'      THEN p.user_id = p_user_id
+      WHEN 'following' THEN
+        p.user_id = p_user_id
+        OR EXISTS (
+          SELECT 1 FROM public.follows f
+          WHERE f.follower_id = p_user_id AND f.following_id = p.user_id
+        )
+      ELSE false
+    END
+    AND CASE
+      WHEN p_cursor_date IS NULL AND p_cursor_created_at IS NULL THEN true
+      WHEN p_cursor_date IS NOT NULL THEN
+        d.date < p_cursor_date
+        OR (d.date = p_cursor_date AND p.created_at < p_cursor_created_at)
+      ELSE
+        p.created_at < p_cursor_created_at
+    END
+  ORDER BY d.date DESC, p.created_at DESC
+  LIMIT p_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_feed(text, uuid, int, date, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_feed(text, uuid, int, date, timestamptz) TO anon;


### PR DESCRIPTION
## Summary
- restrict publishable-key reads on `public.users` to a sanitized column subset
- redact joined user payloads from `get_feed` and keep private profile feed checks intact
- move self-profile and onboarding/auth reads that still need private fields onto the service client

## Testing
- `bun --cwd apps/web test -- __tests__/unit/migration-safety.test.ts __tests__/api/profile.test.ts __tests__/api/feed.test.ts __tests__/api/social.test.ts __tests__/flows/privacy-visibility.test.ts __tests__/flows/profile-and-contributions.test.ts __tests__/flows/signup-to-feed.test.ts`
- `bun --cwd apps/web typecheck` *(fails on existing missing `posthog-js` / `posthog-js/react` modules)*

Closes #82