### PR TITLE
Allow overriding the Codex package source

### DIFF
--- a/packages/cli/__tests__/codex.test.ts
+++ b/packages/cli/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { parseCodexOutput, runCodexRaw } from "../src/lib/codex.js";
 
 vi.mock("node:child_process", () => ({
@@ -227,9 +227,20 @@ describe("parseCodexOutput", () => {
 // ---------------------------------------------------------------------------
 
 describe("runCodexRaw", () => {
+  const originalCodexPkg = process.env.STRAUDE_CODEX_PKG;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.STRAUDE_CODEX_PKG;
     mockExecFileSync.mockReturnValue(validOutput() as never);
+  });
+
+  afterEach(() => {
+    if (originalCodexPkg === undefined) {
+      delete process.env.STRAUDE_CODEX_PKG;
+    } else {
+      process.env.STRAUDE_CODEX_PKG = originalCodexPkg;
+    }
   });
 
   it("returns raw JSON string on success", () => {
@@ -241,5 +252,17 @@ describe("runCodexRaw", () => {
     mockExecFileSync.mockImplementation(() => { throw new Error("fail"); });
     const result = runCodexRaw("20250601", "20250601");
     expect(result).toBe("");
+  });
+
+  it("uses STRAUDE_CODEX_PKG when set", () => {
+    process.env.STRAUDE_CODEX_PKG = "@maxghenis/ccusage-codex@patched";
+
+    runCodexRaw("20250601", "20250601");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["@maxghenis/ccusage-codex@patched", "daily", "--json"]),
+      expect.any(Object),
+    );
   });
 });

--- a/packages/cli/src/lib/codex.ts
+++ b/packages/cli/src/lib/codex.ts
@@ -17,7 +17,12 @@ export interface CodexOutput {
 
 // Pin to major version so bunx/npx can use the cached copy without a registry roundtrip.
 // @latest forces a registry check on every invocation (~200-1000ms penalty).
-const CODEX_PKG = "@ccusage/codex@18";
+const DEFAULT_CODEX_PKG = "@ccusage/codex@18";
+
+function getCodexPackage(): string {
+  const override = process.env.STRAUDE_CODEX_PKG?.trim();
+  return override || DEFAULT_CODEX_PKG;
+}
 
 /** Returns the raw JSON string from @ccusage/codex (for hashing). Empty string on failure. */
 export function runCodexRaw(sinceDate: string, untilDate: string, timeoutMs?: number): string {
@@ -41,7 +46,7 @@ function execCodex(args: string[], timeoutMs?: number): string {
   const cmd = process.versions.bun !== undefined ? "bunx" : "npx";
   const prefix = process.versions.bun !== undefined ? ["--bun"] : ["--yes"];
 
-  return execFileSync(cmd, [...prefix, CODEX_PKG, ...args], {
+  return execFileSync(cmd, [...prefix, getCodexPackage(), ...args], {
     encoding: "utf-8",
     timeout: timeoutMs ?? DEFAULT_SUBPROCESS_TIMEOUT_MS,
     maxBuffer: 10 * 1024 * 1024,
@@ -54,7 +59,7 @@ function execCodexAsync(args: string[], timeoutMs?: number): Promise<string> {
   const prefix = process.versions.bun !== undefined ? ["--bun"] : ["--yes"];
 
   return new Promise((resolve, reject) => {
-    execFileCb(cmd, [...prefix, CODEX_PKG, ...args], {
+    execFileCb(cmd, [...prefix, getCodexPackage(), ...args], {
       encoding: "utf-8",
       timeout: timeoutMs ?? DEFAULT_SUBPROCESS_TIMEOUT_MS,
       maxBuffer: 10 * 1024 * 1024,


### PR DESCRIPTION
## Summary
- add a `STRAUDE_CODEX_PKG` override for the Codex package source
- keep `@ccusage/codex@18` as the default when no override is set
- add CLI tests proving the override is passed through to the subprocess invocation

## Why
Straude currently hardcodes `@ccusage/codex@18`. That means heavy Codex users cannot opt into a patched `@ccusage/codex` build until Straude itself ships a bump.

This PR is a short-term escape hatch only.

For a leaderboard, the real end state should be that Straude points everyone at the accurate `@ccusage/codex` version by default once the upstream fix is merged and published. This override just gives maintainers and affected users a way to validate the corrected numbers before that release exists.

Related:
- fixes / supports discussion in #87
- upstream ccusage issue: ryoppippi/ccusage#897
- upstream fix PR: ryoppippi/ccusage#910
- follow-up fix PR: jackcpku/ccusage#1

## Testing
- `bun --cwd packages/cli test`
- `bun --cwd packages/cli build`
