### PR TITLE
Add GPT-5.5 Codex pricing

### DIFF
--- a/packages/cli/__tests__/codex.test.ts
+++ b/packages/cli/__tests__/codex.test.ts
@@ -155,4 +155,20 @@ describe("native Codex collector", () => {
     expect(entry.costUSD).toBeCloseTo((200 * 0.00000075) + (800 * 0.000000075) + (200 * 0.0000045));
     expect(entry.modelBreakdown).toEqual([{ model: "gpt-5.4-mini", cost_usd: entry.costUSD }]);
   });
+
+  it("prices GPT-5.5 before falling back to GPT-5 pricing", async () => {
+    await writeSession("2026-04-24", "session.jsonl", [
+      meta("s1"),
+      turn("gpt-5.5"),
+      token("2026-04-24T14:00:01.000Z", {
+        total_token_usage: usage(1000, 200, 800),
+      }),
+    ]);
+
+    const result = await collectCodexUsageAsync("20260424", "20260424");
+    const entry = result.data[0]!;
+    expect(entry.models).toEqual(["gpt-5.5"]);
+    expect(entry.costUSD).toBeCloseTo((200 * 0.000005) + (800 * 0.0000005) + (200 * 0.00003));
+    expect(entry.modelBreakdown).toEqual([{ model: "gpt-5.5", cost_usd: entry.costUSD }]);
+  });
 });

--- a/packages/cli/src/lib/codex-native.ts
+++ b/packages/cli/src/lib/codex-native.ts
@@ -85,6 +85,8 @@ const CODEX_PRICING: Record<string, Pricing> = {
   "gpt-5.1-codex-mini": { input: 0.00000025, output: 0.000002, cacheRead: 0.000000025 },
   "gpt-5.2": { input: 0.00000175, output: 0.000014, cacheRead: 0.000000175 },
   "gpt-5.2-codex": { input: 0.00000175, output: 0.000014, cacheRead: 0.000000175 },
+  "gpt-5.5": { input: 0.000005, output: 0.00003, cacheRead: 0.0000005 },
+  "gpt-5.5-pro": { input: 0.00003, output: 0.00018, cacheRead: 0.00003 },
   "gpt-5.4": { input: 0.0000025, output: 0.000015, cacheRead: 0.00000025 },
   "gpt-5.4-2026-03-05": { input: 0.0000025, output: 0.000015, cacheRead: 0.00000025 },
   "gpt-5.4-mini": { input: 0.00000075, output: 0.0000045, cacheRead: 0.000000075 },
@@ -396,6 +398,8 @@ function resolvePricing(model: string): Pricing | undefined {
   const normalized = model.trim().toLowerCase();
   const aliased = CODEX_MODEL_ALIASES[normalized] ?? normalized;
   if (CODEX_PRICING[aliased]) return CODEX_PRICING[aliased];
+  if (aliased.startsWith("gpt-5.5-pro")) return CODEX_PRICING["gpt-5.5-pro"];
+  if (aliased.startsWith("gpt-5.5")) return CODEX_PRICING["gpt-5.5"];
   if (aliased.startsWith("gpt-5.4-mini")) return CODEX_PRICING["gpt-5.4-mini"];
   if (aliased.startsWith("gpt-5.4-nano")) return CODEX_PRICING["gpt-5.4-nano"];
   if (aliased.startsWith("gpt-5.4")) return CODEX_PRICING["gpt-5.4"];


### PR DESCRIPTION
## Summary
- add native Codex pricing entries for GPT-5.5 and GPT-5.5 Pro
- resolve GPT-5.5 model prefixes before the generic GPT-5 fallback
- add a focused native collector test that prices GPT-5.5 correctly

## Why
After #92 moved Codex accounting to Straude's native collector, GPT-5.5 model names fell through to baseline GPT-5 pricing. That underprices GPT-5.5 usage in pushed totals and model breakdowns.

Pricing references:
- https://openai.com/api/pricing/
- https://developers.openai.com/api/docs/models/gpt-5.5

## Testing
- `bun --cwd packages/cli test -- codex.test.ts`
- `bun --cwd packages/cli build`
- `bun --cwd packages/cli test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new Codex models `gpt-5.5` and `gpt-5.5-pro` with correct pricing configuration and usage attribution.

* **Tests**
  * Added test case verifying proper usage tracking and cost calculation for the new models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->