### PR TITLE
fix(cli): silence one-time Codex repair log line

### DIFF
--- a/packages/cli/__tests__/commands/push.test.ts
+++ b/packages/cli/__tests__/commands/push.test.ts
@@ -319,9 +319,6 @@ describe("pushCommand", () => {
     twentyNineDaysAgo.setDate(now.getDate() - 29);
     expect(sinceArg).toBe(fmt(twentyNineDaysAgo));
     expect(untilArg).toBe(fmt(now));
-    expect(console.log).toHaveBeenCalledWith(
-      "Repairing Codex totals with a one-time 30-day resync...",
-    );
     expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({
       codex_native_repair_completed_at: expect.any(String),
       last_push_date: today,

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -205,7 +205,6 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
     sinceDate = new Date(today);
     sinceDate.setDate(sinceDate.getDate() - MAX_BACKFILL_DAYS + 1);
     untilDate = today;
-    console.log(`Repairing Codex totals with a one-time ${MAX_BACKFILL_DAYS}-day resync...`);
   } else if (options.days) {
     const days = Math.min(options.days, MAX_BACKFILL_DAYS);
     sinceDate = new Date(today);


### PR DESCRIPTION
## Summary

Removes the `Repairing Codex totals with a one-time 30-day resync...` console.log from `straude push`. The repair logic itself is unchanged — the 30-day backfill still happens once per device, gated by `codex_native_repair_completed_at` — it just no longer announces itself.

## Test plan

- [x] `bun run test` (202 tests pass)
- [x] Test that asserted on the log line was updated
- [ ] Manual: run `straude push` on a fresh install with Codex logs — should sync silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test case for Codex repair operation to reflect message removal.

* **Chores**
  * Removed informational console message from the push command's Codex repair workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->