### PR TITLE
Validate stored profile links

### DIFF
--- a/apps/web/__tests__/api/profile.test.ts
+++ b/apps/web/__tests__/api/profile.test.ts
@@ -275,6 +275,35 @@ describe("GET /api/users/me", () => {
 });
 
 describe("PATCH /api/users/me", () => {
+  function mockAuthenticatedProfileUpdate(resultData: Record<string, unknown> = { id: "u-1" }) {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: resultData,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "u-1" } },
+          error: null,
+        }),
+      },
+    };
+    const db = {
+      from: vi.fn().mockReturnValue({ update: updateMock }),
+    };
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
+
+    return { updateMock };
+  }
+
   it("updates profile fields", async () => {
     const updatedProfile = {
       id: "u-1",
@@ -399,6 +428,60 @@ describe("PATCH /api/users/me", () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain("500 characters");
+  });
+
+  it("accepts valid http and https profile links", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+
+    let res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { link: " https://example.com/me " })
+    );
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenLastCalledWith({ link: "https://example.com/me" });
+
+    res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { link: "http://example.com/me" })
+    );
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenLastCalledWith({ link: "http://example.com/me" });
+  });
+
+  it("clears blank or null profile links", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+
+    let res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { link: "" })
+    );
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenLastCalledWith({ link: null });
+
+    res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { link: null })
+    );
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenLastCalledWith({ link: null });
+  });
+
+  it("rejects unsafe or malformed profile links", async () => {
+    const client: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "u-1" } },
+          error: null,
+        }),
+      },
+    };
+    (createClient as any).mockResolvedValue(client);
+
+    for (const link of ["javascript:alert(1)", "data:text/html,<p>x</p>", "not a url"]) {
+      const res = await PATCH(
+        makeRequest("PATCH", "/api/users/me", { link })
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain("Profile link");
+    }
   });
 
   it("auto-derives region from country", async () => {

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -25,6 +25,29 @@ const ALLOWED_FIELDS = [
 const BIO_MAX_LENGTH = 160;
 const HEARD_ABOUT_MAX_LENGTH = 500;
 
+function normalizeProfileLink(value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    throw new Error("Profile link must be a URL");
+  }
+
+  const link = value.trim();
+  if (!link) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(link);
+  } catch {
+    throw new Error("Profile link must be a valid URL");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Profile link must use http or https");
+  }
+
+  return link;
+}
+
 export async function GET() {
   const supabase = await createClient();
   const {
@@ -120,6 +143,17 @@ export async function PATCH(request: NextRequest) {
     } else {
       return NextResponse.json(
         { error: "How you heard about Straude must be text" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (updates.link !== undefined) {
+    try {
+      updates.link = normalizeProfileLink(updates.link);
+    } catch (error) {
+      return NextResponse.json(
+        { error: (error as Error).message },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Summary
- normalize profile links in PATCH /api/users/me before storing
- allow http/https links and explicit clears
- reject malformed or unsafe schemes before public profile rendering

## Verification
- bunx vitest run --pool=threads __tests__/api/profile.test.ts
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- pre-push full build/test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile link validation. Links must be valid HTTP/HTTPS URLs, whitespace is automatically trimmed, invalid entries are rejected with error messages, and blank inputs clear the link.

* **Tests**
  * Enhanced profile update tests to cover link validation scenarios including URL format validation and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->