### PR TITLE
Use avatars bucket for profile uploads

### DIFF
--- a/apps/web/__tests__/api/upload.test.ts
+++ b/apps/web/__tests__/api/upload.test.ts
@@ -335,6 +335,24 @@ describe("POST /api/upload", () => {
     expect(json.url).toBe("https://cdn.example.com/user-1/uuid.jpg");
   });
 
+  it("uploads avatars to the avatars bucket", async () => {
+    const client = mockSupabase({
+      publicUrl: "https://cdn.example.com/user-1/avatar.jpg",
+    });
+
+    const res = await POST(
+      makeUploadRequest(
+        { name: "avatar.jpg", type: "image/jpeg", size: 100 },
+        "avatars",
+      )
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.url).toBe("https://cdn.example.com/user-1/avatar.jpg");
+    expect(client.storage.from).toHaveBeenCalledWith("avatars");
+  });
+
   it("returns storage metadata instead of a public URL for DM attachments", async () => {
     mockSupabase({ publicUrl: "https://cdn.example.com/user-1/private.pdf" });
 

--- a/apps/web/__tests__/unit/storage.test.ts
+++ b/apps/web/__tests__/unit/storage.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isAllowedAvatarUrl } from "@/lib/storage";
+
+describe("storage avatar URL safety", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
+  });
+
+  it("allows first-party avatar bucket URLs", () => {
+    expect(
+      isAllowedAvatarUrl(
+        "https://test.supabase.co/storage/v1/object/public/avatars/user-1/avatar.jpg"
+      )
+    ).toBe(true);
+  });
+
+  it("allows legacy first-party post image avatar URLs", () => {
+    expect(
+      isAllowedAvatarUrl(
+        "https://test.supabase.co/storage/v1/object/public/post-images/user-1/avatar.jpg"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects first-party URLs from non-avatar buckets", () => {
+    expect(
+      isAllowedAvatarUrl(
+        "https://test.supabase.co/storage/v1/object/public/dm-attachments/user-1/file.jpg"
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -89,7 +89,7 @@ export default function SettingsPage() {
       const form = new FormData();
       form.append("file", compressed);
 
-      const uploadRes = await fetch("/api/upload?bucket=post-images", {
+      const uploadRes = await fetch("/api/upload?bucket=avatars", {
         method: "POST",
         body: form,
       });

--- a/apps/web/app/api/posts/[id]/share-image/route.tsx
+++ b/apps/web/app/api/posts/[id]/share-image/route.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { ShareCardImage } from "@/lib/utils/share-image";
 import { DEFAULT_SHARE_THEME, type ShareThemeId } from "@/lib/share-themes";
 import { loadFonts } from "@/lib/og-fonts";
-import { isFirstPartyPublicStorageUrl } from "@/lib/storage";
+import { isAllowedAvatarUrl, isFirstPartyPublicStorageUrl } from "@/lib/storage";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
   } | null;
   const safeAvatarUrl =
     typeof u?.avatar_url === "string" &&
-      isFirstPartyPublicStorageUrl(u.avatar_url, "avatars")
+      isAllowedAvatarUrl(u.avatar_url)
       ? u.avatar_url
       : null;
   const safeImages = Array.isArray(post.images)

--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -25,10 +25,14 @@ const DM_FILE_TYPES = [
   "application/zip",
 ];
 
-const VALID_BUCKETS = ["post-images", "dm-attachments"] as const;
+const VALID_BUCKETS = ["avatars", "post-images", "dm-attachments"] as const;
 type BucketId = (typeof VALID_BUCKETS)[number];
 
 const BUCKET_CONFIG: Record<BucketId, { maxSize: number; allowedTypes: string[] }> = {
+  avatars: {
+    maxSize: 5 * 1024 * 1024,
+    allowedTypes: IMAGE_TYPES,
+  },
   "post-images": {
     maxSize: 20 * 1024 * 1024,
     allowedTypes: IMAGE_TYPES,

--- a/apps/web/lib/storage.ts
+++ b/apps/web/lib/storage.ts
@@ -66,7 +66,10 @@ const ALLOWED_AVATAR_HOSTS = new Set([
 ]);
 
 export function isAllowedAvatarUrl(url: string): boolean {
-  if (isFirstPartyPublicStorageUrl(url, "avatars")) {
+  if (
+    isFirstPartyPublicStorageUrl(url, "avatars") ||
+    isFirstPartyPublicStorageUrl(url, "post-images")
+  ) {
     return true;
   }
   try {


### PR DESCRIPTION
## Summary
- add avatars as a supported upload bucket with avatar image limits
- upload settings avatars to the avatars bucket instead of post-images
- use the shared avatar URL allowlist for generated share images, including legacy first-party post-images avatar URLs

## Verification
- bunx vitest run --pool=threads __tests__/api/upload.test.ts __tests__/unit/storage.test.ts __tests__/api/post-share-image.test.ts
- bunx vitest run --pool=threads __tests__/api/profile.test.ts __tests__/api/upload.test.ts
- bun run --cwd apps/web typecheck (after clearing stale .next types from prior branch)
- bun run --cwd apps/web lint
- pre-push full build/test suite