### PR TITLE
Restrict stored avatar URLs

### DIFF
--- a/apps/web/__tests__/api/profile.test.ts
+++ b/apps/web/__tests__/api/profile.test.ts
@@ -36,6 +36,7 @@ function makeRequest(method: string, url: string, body?: any) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
 });
 
 describe("GET /api/users/[username]", () => {
@@ -275,6 +276,35 @@ describe("GET /api/users/me", () => {
 });
 
 describe("PATCH /api/users/me", () => {
+  function mockAuthenticatedProfileUpdate(resultData: Record<string, unknown> = { id: "u-1" }) {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: resultData,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "u-1" } },
+          error: null,
+        }),
+      },
+    };
+    const db = {
+      from: vi.fn().mockReturnValue({ update: updateMock }),
+    };
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
+
+    return { updateMock };
+  }
+
   it("updates profile fields", async () => {
     const updatedProfile = {
       id: "u-1",
@@ -399,6 +429,78 @@ describe("PATCH /api/users/me", () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain("500 characters");
+  });
+
+  it("accepts owned uploaded avatar URLs", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+    const avatarUrl =
+      "https://test.supabase.co/storage/v1/object/public/avatars/u-1/avatar.jpg";
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { avatar_url: ` ${avatarUrl} ` })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith({ avatar_url: avatarUrl });
+  });
+
+  it("accepts allowed external avatar URLs", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+    const avatarUrl = "https://avatars.githubusercontent.com/u/123";
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { avatar_url: avatarUrl })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith({ avatar_url: avatarUrl });
+  });
+
+  it("clears blank or null avatar URLs", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+
+    let res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { avatar_url: "" })
+    );
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenLastCalledWith({ avatar_url: null });
+
+    res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { avatar_url: null })
+    );
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenLastCalledWith({ avatar_url: null });
+  });
+
+  it("rejects arbitrary avatar hosts", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", {
+        avatar_url: "https://example.com/avatar.jpg",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Avatar URL is not allowed");
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects first-party avatar storage paths owned by another user", async () => {
+    const { updateMock } = mockAuthenticatedProfileUpdate();
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", {
+        avatar_url:
+          "https://test.supabase.co/storage/v1/object/public/avatars/u-2/avatar.jpg",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Avatar URL is not allowed");
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   it("auto-derives region from country", async () => {

--- a/apps/web/__tests__/unit/storage.test.ts
+++ b/apps/web/__tests__/unit/storage.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isAllowedAvatarUrl } from "@/lib/storage";
+import { isAllowedAvatarUrl, isAllowedUserAvatarUrl } from "@/lib/storage";
 
 describe("storage avatar URL safety", () => {
   beforeEach(() => {
@@ -26,6 +26,27 @@ describe("storage avatar URL safety", () => {
     expect(
       isAllowedAvatarUrl(
         "https://test.supabase.co/storage/v1/object/public/dm-attachments/user-1/file.jpg"
+      )
+    ).toBe(false);
+  });
+
+  it("requires first-party avatar storage URLs to be owned by the user", () => {
+    expect(
+      isAllowedUserAvatarUrl(
+        "https://test.supabase.co/storage/v1/object/public/avatars/user-1/avatar.jpg",
+        "user-1"
+      )
+    ).toBe(true);
+    expect(
+      isAllowedUserAvatarUrl(
+        "https://test.supabase.co/storage/v1/object/public/post-images/user-1/avatar.jpg",
+        "user-1"
+      )
+    ).toBe(true);
+    expect(
+      isAllowedUserAvatarUrl(
+        "https://test.supabase.co/storage/v1/object/public/avatars/user-2/avatar.jpg",
+        "user-1"
       )
     ).toBe(false);
   });

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -4,6 +4,7 @@ import { getServiceClient } from "@/lib/supabase/service";
 import { COUNTRY_TO_REGION } from "@/lib/constants/regions";
 import { sendWelcomeEmail } from "@/lib/email/send-welcome-email";
 import { attributeReferral } from "@/lib/referral";
+import { isAllowedUserAvatarUrl } from "@/lib/storage";
 
 const ALLOWED_FIELDS = [
   "username",
@@ -120,6 +121,29 @@ export async function PATCH(request: NextRequest) {
     } else {
       return NextResponse.json(
         { error: "How you heard about Straude must be text" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (updates.avatar_url !== undefined) {
+    if (updates.avatar_url === null) {
+      // Allow callers to clear the field explicitly.
+    } else if (typeof updates.avatar_url === "string") {
+      const avatarUrl = updates.avatar_url.trim();
+      if (!avatarUrl) {
+        updates.avatar_url = null;
+      } else if (isAllowedUserAvatarUrl(avatarUrl, user.id)) {
+        updates.avatar_url = avatarUrl;
+      } else {
+        return NextResponse.json(
+          { error: "Avatar URL is not allowed" },
+          { status: 400 }
+        );
+      }
+    } else {
+      return NextResponse.json(
+        { error: "Avatar URL must be a URL" },
         { status: 400 }
       );
     }

--- a/apps/web/lib/storage.ts
+++ b/apps/web/lib/storage.ts
@@ -65,13 +65,9 @@ const ALLOWED_AVATAR_HOSTS = new Set([
   "api.dicebear.com",
 ]);
 
-export function isAllowedAvatarUrl(url: string): boolean {
-  if (
-    isFirstPartyPublicStorageUrl(url, "avatars") ||
-    isFirstPartyPublicStorageUrl(url, "post-images")
-  ) {
-    return true;
-  }
+const AVATAR_STORAGE_BUCKETS: StorageBucket[] = ["avatars", "post-images"];
+
+function isAllowedExternalAvatarUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;
@@ -79,6 +75,22 @@ export function isAllowedAvatarUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+export function isAllowedAvatarUrl(url: string): boolean {
+  if (AVATAR_STORAGE_BUCKETS.some((bucket) => isFirstPartyPublicStorageUrl(url, bucket))) {
+    return true;
+  }
+  return isAllowedExternalAvatarUrl(url);
+}
+
+export function isAllowedUserAvatarUrl(url: string, userId: string): boolean {
+  const isOwnedStorageUrl = AVATAR_STORAGE_BUCKETS.some((bucket) => {
+    const path = extractPublicStoragePath(url, bucket);
+    return path !== null && isStoragePathOwnedByUser(path, userId);
+  });
+
+  return isOwnedStorageUrl || isAllowedExternalAvatarUrl(url);
 }
 
 export function normalizeMessageAttachmentInput(


### PR DESCRIPTION
## Summary
- validate avatar_url in PATCH /api/users/me before storing
- allow clears, known external avatar hosts, and owned first-party avatars/post-images storage URLs
- reject arbitrary hosts and first-party storage paths owned by another user

## Stack
- Base PR: #103 (avatar upload bucket consistency)

## Verification
- bunx vitest run --pool=threads __tests__/api/profile.test.ts __tests__/unit/storage.test.ts __tests__/api/upload.test.ts
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- pre-push full build/test suite