### PR TITLE
Preserve cleared optional profile fields

### DIFF
--- a/apps/web/__tests__/unit/settings-payload.test.ts
+++ b/apps/web/__tests__/unit/settings-payload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildProfileUpdatePayload } from "@/app/(app)/settings/page";
+
+const baseInput = {
+  username: "alice",
+  displayName: "Alice",
+  bio: "Builder",
+  heardAbout: "Friend",
+  link: "https://example.com",
+  country: "US",
+  githubUsername: "alicehub",
+  isPublic: true,
+  emailNotifications: true,
+  emailMentionNotifications: true,
+  emailDmNotifications: true,
+  timezone: "America/Vancouver",
+};
+
+describe("settings profile update payload", () => {
+  it("sends null for cleared optional profile fields", () => {
+    expect(
+      buildProfileUpdatePayload({
+        ...baseInput,
+        displayName: "",
+        bio: "",
+        link: "",
+        country: "",
+        githubUsername: "",
+      })
+    ).toMatchObject({
+      username: "alice",
+      display_name: null,
+      bio: null,
+      link: null,
+      country: null,
+      github_username: null,
+    });
+  });
+
+  it("does not clear username when the field is blank", () => {
+    expect(
+      buildProfileUpdatePayload({
+        ...baseInput,
+        username: " ",
+      })
+    ).toMatchObject({
+      username: undefined,
+      display_name: "Alice",
+    });
+  });
+
+  it("trims optional text fields before saving", () => {
+    expect(
+      buildProfileUpdatePayload({
+        ...baseInput,
+        displayName: " Alice Liddell ",
+        bio: " Hello ",
+        link: " https://example.com/me ",
+        githubUsername: " alice ",
+      })
+    ).toMatchObject({
+      display_name: "Alice Liddell",
+      bio: "Hello",
+      link: "https://example.com/me",
+      github_username: "alice",
+    });
+  });
+});

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -15,6 +15,38 @@ import { usePostHog } from "posthog-js/react";
 import { compressImage } from "@/lib/utils/compress-image";
 import { CountryPicker } from "@/components/ui/CountryPicker";
 
+type ProfileUpdatePayloadInput = {
+  username: string;
+  displayName: string;
+  bio: string;
+  heardAbout: string;
+  link: string;
+  country: string;
+  githubUsername: string;
+  isPublic: boolean;
+  emailNotifications: boolean;
+  emailMentionNotifications: boolean;
+  emailDmNotifications: boolean;
+  timezone: string;
+};
+
+export function buildProfileUpdatePayload(input: ProfileUpdatePayloadInput) {
+  return {
+    username: input.username.trim() || undefined,
+    display_name: input.displayName.trim() || null,
+    bio: input.bio.trim() || null,
+    heard_about: input.heardAbout.trim() || null,
+    link: input.link.trim() || null,
+    country: input.country || null,
+    github_username: input.githubUsername.trim() || null,
+    is_public: input.isPublic,
+    email_notifications: input.emailNotifications,
+    email_mention_notifications: input.emailMentionNotifications,
+    email_dm_notifications: input.emailDmNotifications,
+    timezone: input.timezone,
+  };
+}
+
 export default function SettingsPage() {
   const router = useRouter();
   const posthog = usePostHog();
@@ -129,20 +161,20 @@ export default function SettingsPage() {
     const res = await fetch("/api/users/me", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        username: username || undefined,
-        display_name: displayName || undefined,
-        bio: bio || undefined,
-        heard_about: heardAbout.trim() || null,
-        link: link || undefined,
-        country: country || undefined,
-        github_username: githubUsername || undefined,
-        is_public: isPublic,
-        email_notifications: emailNotifications,
-        email_mention_notifications: emailMentionNotifications,
-        email_dm_notifications: emailDmNotifications,
+      body: JSON.stringify(buildProfileUpdatePayload({
+        username,
+        displayName,
+        bio,
+        heardAbout,
+        link,
+        country,
+        githubUsername,
+        isPublic,
+        emailNotifications,
+        emailMentionNotifications,
+        emailDmNotifications,
         timezone,
-      }),
+      })),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- centralize settings profile update payload construction
- send null when optional profile fields are cleared
- keep blank username as omitted so settings cannot accidentally clear it

## Verification
- bunx vitest run --pool=threads __tests__/unit/settings-payload.test.ts
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- pre-push full build/test suite