### PR TITLE
[codex] Fix bern community prompt bugs

### DIFF
--- a/apps/web/__tests__/api/posts.test.ts
+++ b/apps/web/__tests__/api/posts.test.ts
@@ -20,9 +20,13 @@ vi.mock("@/lib/supabase/service", () => ({
 vi.mock("@/lib/email/send-comment-email", () => ({
   sendNotificationEmail: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("@/lib/achievements", () => ({
+  checkAndAwardAchievements: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { GET, PATCH, DELETE } from "@/app/api/posts/[id]/route";
 import { createClient } from "@/lib/supabase/server";
+import { checkAndAwardAchievements } from "@/lib/achievements";
 import { NextRequest } from "next/server";
 
 function buildChain(overrides: Record<string, any> = {}) {
@@ -290,6 +294,55 @@ describe("PATCH /api/posts/[id]", () => {
 
     expect(res.status).toBe(200);
     expect(insertFn).not.toHaveBeenCalled();
+  });
+
+  it("waits for first-photo achievement awarding when images are saved", async () => {
+    let resolveAchievement!: () => void;
+    const achievementPromise = new Promise<void>((resolve) => {
+      resolveAchievement = resolve;
+    });
+    const awardMock = vi.mocked(checkAndAwardAchievements);
+    awardMock.mockReturnValueOnce(achievementPromise);
+
+    mockSupabase({
+      user: { id: "user-1" },
+      tableHandlers: {
+        posts: (c) => {
+          c.single.mockResolvedValue({
+            data: {
+              id: "post-1",
+              description: null,
+              title: null,
+              images: [
+                "https://test.supabase.co/storage/v1/object/public/post-images/user-1/img1.jpg",
+              ],
+            },
+            error: null,
+          });
+        },
+      },
+    });
+
+    let settled = false;
+    const responsePromise = PATCH(
+      makeRequest("PATCH", {
+        images: [
+          "https://test.supabase.co/storage/v1/object/public/post-images/user-1/img1.jpg",
+        ],
+      }),
+      makeContext("post-1"),
+    ).finally(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+    expect(awardMock).toHaveBeenCalledExactlyOnceWith("user-1", "photo");
+
+    resolveAchievement();
+    const res = await responsePromise;
+
+    expect(res.status).toBe(200);
   });
 
   it("rejects external image URLs", async () => {

--- a/apps/web/__tests__/components/ResponsiveShellFrame.test.tsx
+++ b/apps/web/__tests__/components/ResponsiveShellFrame.test.tsx
@@ -63,4 +63,50 @@ describe("ResponsiveShellFrame", () => {
     expect(screen.queryByText("Right rail content")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /open panels/i })).toBeInTheDocument();
   });
+
+  it("keeps desktop rails and main content in hidden-scrollbar scroll regions", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ResponsiveShellFrame
+          username="alice"
+          avatarUrl={null}
+          leftPanel={<div>Left rail content</div>}
+          rightPanel={<div>Right rail content</div>}
+        >
+          <div>Page content</div>
+        </ResponsiveShellFrame>
+      </QueryClientProvider>,
+    );
+
+    const rails = Array.from(container.querySelectorAll("aside"));
+    expect(rails).toHaveLength(2);
+
+    for (const rail of rails) {
+      expect(rail).toHaveClass(
+        "scrollbar-none",
+        "min-h-0",
+        "overflow-y-auto",
+        "overflow-x-hidden",
+      );
+    }
+
+    expect(screen.getByRole("main")).toHaveClass(
+      "scrollbar-none",
+      "overflow-y-auto",
+      "overflow-x-hidden",
+      "overscroll-contain",
+    );
+  });
 });

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -313,8 +313,8 @@ export default async function AppLayout({
     return (
       <div className="fixed inset-0 flex flex-col overflow-hidden">
         <GuestHeader />
-          <div className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 border-x border-border">
-            <main id="main-content" className="min-w-0 flex-1 overflow-y-auto" style={{ scrollbarWidth: "none", overscrollBehavior: "contain" }}>
+          <div className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 overflow-hidden border-x border-border">
+            <main id="main-content" className="scrollbar-none min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
               <div className="pb-[var(--mobile-nav-height)] sm:pb-0">
                 {children}
               </div>

--- a/apps/web/app/api/posts/[id]/route.ts
+++ b/apps/web/app/api/posts/[id]/route.ts
@@ -145,13 +145,16 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     );
   }
 
+  if (body.images !== undefined && Array.isArray(body.images) && body.images.length > 0) {
+    try {
+      await checkAndAwardAchievements(user.id, "photo");
+    } catch (err) {
+      console.error("[achievements] first-photo award failed:", err);
+    }
+  }
+
   // Defer non-blocking work after the response is sent
   after(async () => {
-    // Photo achievement — when images were added
-    if (body.images !== undefined && Array.isArray(post.images) && post.images.length > 0) {
-      checkAndAwardAchievements(user.id, "photo").catch(() => {});
-    }
-
     // Award streak freeze when enriching a bare post (first time adding title or description)
     const wasBare = currentPost && currentPost.title === null && currentPost.description === null;
     const isEnriching = wasBare && (body.title || body.description);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -128,6 +128,15 @@ body {
   text-wrap: pretty;
 }
 
+.scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 /* PWA safe area insets for notched devices */
 .safe-top { padding-top: env(safe-area-inset-top); }
 .safe-bottom { padding-bottom: env(safe-area-inset-bottom); }

--- a/apps/web/components/app/shared/ResponsiveShellFrame.tsx
+++ b/apps/web/components/app/shared/ResponsiveShellFrame.tsx
@@ -54,13 +54,13 @@ export function ResponsiveShellFrame({
         }
       />
 
-      <div className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 border-x border-border">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 overflow-hidden border-x border-border">
         {showLeftRail && (
           <div 
             className={cn("relative shrink-0 border-r border-border", leftCollapsed && "w-6")}
           >
             <aside
-              className="h-full overflow-y-auto overflow-x-hidden overscroll-contain transition-[width] duration-200"
+              className="scrollbar-none h-full min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain transition-[width] duration-200"
               style={{ width: leftCollapsed ? 0 : "var(--app-left-panel-width)" }}
             >
               <div style={{ width: "var(--app-left-panel-width)" }}>
@@ -85,8 +85,7 @@ export function ResponsiveShellFrame({
 
         <main
           id="main-content"
-          className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden"
-          style={{ scrollbarWidth: "none", overscrollBehavior: "contain" }}
+          className="scrollbar-none min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain"
         >
           <div className="flex h-full flex-col pb-[var(--app-main-bottom-offset)]">
             {children}
@@ -98,7 +97,7 @@ export function ResponsiveShellFrame({
             className={cn("relative shrink-0 border-l border-border", rightCollapsed && "w-6")}
           >
             <aside
-              className="h-full overflow-y-auto overflow-x-hidden overscroll-contain transition-[width] duration-200"
+              className="scrollbar-none h-full min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain transition-[width] duration-200"
               style={{ width: rightCollapsed ? 0 : "var(--app-right-panel-width)" }}
             >
               <div style={{ width: "var(--app-right-panel-width)" }}>


### PR DESCRIPTION
## Summary
- Investigated the @bern community prompt reports visible in the community prompts modal.
- Fixed the reproducible first-photo achievement/banner race by waiting for the photo achievement award before the post PATCH response returns when saved images are present.
- Fixed the reproducible shell sidebar overflow/scrollbar issue by clipping the app shell frame and applying one cross-browser hidden-scrollbar utility to desktop rails, main content, and the guest shell.
- Confirmed the feed image zoom/readability report was already resolved on main: `ImageGrid` uses `object-contain` and the regression test still passes.

## Root Cause
- First photo: the route deferred `checkAndAwardAchievements(user.id, "photo")` through `after()`, while `PostEditor` immediately calls `router.refresh()` after a successful save. That let the top photo nudge re-render before `user_achievements` had the `first-photo` row.
- Sidebar overflow/scrollbar: the shell had scrollable regions, but the frame did not clip overflow and the side rails lacked the same cross-browser hidden-scrollbar behavior as the main column.

## Validation
- `bun install`
- `bun --cwd packages/shared build`
- `bun --cwd apps/web test __tests__/api/posts.test.ts __tests__/components/ResponsiveShellFrame.test.tsx __tests__/components/ImageGrid.test.tsx`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_placeholder SUPABASE_SECRET_KEY=sb_secret_placeholder bun --cwd apps/web build`

Note: the build completed successfully; it logs expected placeholder-Supabase connection warnings during static generation because the local Supabase stack was not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrollbar handling and scroll containment across the app layout for better visual consistency.
  * Refined scrolling behavior on desktop views with enhanced overflow management.

* **Bug Fixes**
  * Fixed scroll behavior in responsive layout components to properly contain content overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->