### PR TITLE
fix: return user lifetime total cost

### DIFF
--- a/apps/web/__tests__/api/profile.test.ts
+++ b/apps/web/__tests__/api/profile.test.ts
@@ -86,7 +86,7 @@ describe("GET /api/users/[username]", () => {
           return {
             select: vi.fn().mockReturnValue({
               eq: vi.fn().mockResolvedValue({
-                data: [{ cost_usd: 15 }],
+                data: [{ total_cost: 15 }],
                 error: null,
               }),
             }),

--- a/apps/web/__tests__/flows/privacy-visibility.test.ts
+++ b/apps/web/__tests__/flows/privacy-visibility.test.ts
@@ -134,7 +134,7 @@ describe("Flow: Privacy and Visibility", () => {
     const costChain = chainBuilder();
     (costChain.select as ReturnType<typeof vi.fn>).mockReturnValue(costChain);
     (costChain.eq as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ cost_usd: 50.0 }],
+      data: [{ total_cost: 50.0 }],
     });
 
     const weeklyChain = chainBuilder();

--- a/apps/web/__tests__/flows/profile-and-contributions.test.ts
+++ b/apps/web/__tests__/flows/profile-and-contributions.test.ts
@@ -136,7 +136,7 @@ describe("Flow: Profile and Contributions", () => {
     const costChain = chainBuilder();
     (costChain.select as ReturnType<typeof vi.fn>).mockReturnValue(costChain);
     (costChain.eq as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [{ cost_usd: 10.0 }],
+      data: [{ total_cost: 10.0 }],
     });
 
     // Leaderboard rank

--- a/apps/web/app/api/users/[username]/route.ts
+++ b/apps/web/app/api/users/[username]/route.ts
@@ -17,7 +17,7 @@ type PublicProfileRow = {
   streak_freezes: number | null;
 };
 type TotalCostAggregateRow = {
-  cost_usd: number | string | null;
+  total_cost: number | string | null;
 };
 
 export async function GET(_request: NextRequest, context: RouteContext) {
@@ -65,7 +65,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     }),
     db
       .from("daily_usage")
-      .select("cost_usd.sum()")
+      .select("total_cost:cost_usd.sum()")
       .eq("user_id", profile.id),
     db
       .from("user_levels")
@@ -83,7 +83,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
 
   const streak = typeof streakRes.data === "number" ? streakRes.data : 0;
   const totalCostRows = totalCostRes.data as TotalCostAggregateRow[] | null;
-  const total_cost = Number(totalCostRows?.[0]?.cost_usd ?? 0);
+  const total_cost = Number(totalCostRows?.[0]?.total_cost ?? 0);
   const is_following = !isOwn && !!authUserId && isFollowing;
 
   // Rank queries (depend on weekly leaderboard entry)


### PR DESCRIPTION
## Summary
- alias the daily_usage cost aggregate as total_cost in GET /api/users/:username
- read the aliased aggregate result instead of the nonexistent cost_usd key
- update existing profile test fixtures to match the PostgREST aggregate shape

## Verification
- git diff --cached --check before commit
- attempted focused Vitest route tests, but this workspace has a partial node_modules install and cannot resolve next/server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mocks for user profile queries, privacy visibility checks, and contribution statistics to align with the revised API response schema for cost data.

* **Chore**
  * Refined the user profile API endpoint to standardize cost data field naming and improve consistency in how cost information is retrieved and formatted in responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohong/straude/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->