### PR TITLE
fix(db): harden get_following_feed against impersonation

### DIFF
--- a/supabase/migrations/20260504090000_harden_get_following_feed_rpc_auth.sql
+++ b/supabase/migrations/20260504090000_harden_get_following_feed_rpc_auth.sql
@@ -25,6 +25,7 @@ SET search_path TO 'public'
 AS $$
 DECLARE
   v_caller_id uuid;
+  v_limit     int;
 BEGIN
   v_caller_id := auth.uid();
 
@@ -37,6 +38,9 @@ BEGIN
     RAISE EXCEPTION 'Forbidden: p_user_id must match auth.uid()'
       USING ERRCODE = '42501';
   END IF;
+
+  -- Clamp the page size so a caller cannot request an unbounded result set.
+  v_limit := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
 
   RETURN QUERY
   SELECT
@@ -64,7 +68,7 @@ BEGIN
   )
   AND (p_cursor IS NULL OR p.created_at < p_cursor)
   ORDER BY p.created_at DESC
-  LIMIT p_limit;
+  LIMIT v_limit;
 END;
 $$;
 

--- a/supabase/migrations/20260504090000_harden_get_following_feed_rpc_auth.sql
+++ b/supabase/migrations/20260504090000_harden_get_following_feed_rpc_auth.sql
@@ -1,0 +1,72 @@
+-- Harden get_following_feed to prevent user impersonation via SECURITY DEFINER.
+CREATE OR REPLACE FUNCTION public.get_following_feed(
+  p_user_id uuid,
+  p_limit   int DEFAULT 20,
+  p_cursor  timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  id              uuid,
+  user_id         uuid,
+  daily_usage_id  uuid,
+  title           text,
+  description     text,
+  images          jsonb,
+  created_at      timestamptz,
+  updated_at      timestamptz,
+  "user"          jsonb,
+  daily_usage     jsonb,
+  kudos_count     bigint,
+  comment_count   bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_caller_id uuid;
+BEGIN
+  v_caller_id := auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Unauthorized'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_user_id IS DISTINCT FROM v_caller_id THEN
+    RAISE EXCEPTION 'Forbidden: p_user_id must match auth.uid()'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.user_id,
+    p.daily_usage_id,
+    p.title,
+    p.description,
+    p.images,
+    p.created_at,
+    p.updated_at,
+    to_jsonb(u.*) AS "user",
+    to_jsonb(d.*) AS daily_usage,
+    (SELECT COUNT(*) FROM public.kudos k WHERE k.post_id = p.id) AS kudos_count,
+    (SELECT COUNT(*) FROM public.comments c WHERE c.post_id = p.id) AS comment_count
+  FROM public.posts p
+  JOIN public.users u ON u.id = p.user_id
+  LEFT JOIN public.daily_usage d ON d.id = p.daily_usage_id
+  WHERE (
+    p.user_id = v_caller_id
+    OR EXISTS (
+      SELECT 1 FROM public.follows f
+      WHERE f.follower_id = v_caller_id AND f.following_id = p.user_id
+    )
+  )
+  AND (p_cursor IS NULL OR p.created_at < p_cursor)
+  ORDER BY p.created_at DESC
+  LIMIT p_limit;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_following_feed(uuid, int, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_following_feed(uuid, int, timestamptz) TO authenticated;


### PR DESCRIPTION
### Motivation
- The `public.get_following_feed` RPC was declared `SECURITY DEFINER` but trusted the caller-supplied `p_user_id`, allowing callers to impersonate other users and bypass RLS to read private posts and `daily_usage` JSON. 
- This posed a high-severity confidentiality exposure because the function returns joined user and usage data and was granted to `authenticated` without revoking `PUBLIC`. 

### Description
- Add a new migration `supabase/migrations/20260504090000_harden_get_following_feed_rpc_auth.sql` that `CREATE OR REPLACE FUNCTION public.get_following_feed(...)` and preserves the original signature and result shape. 
- Inside the function the migration reads `v_caller_id := auth.uid()`, rejects unauthenticated callers, and raises `Forbidden` if `p_user_id` is distinct from `v_caller_id`, then uses `v_caller_id` in the feed predicate. 
- The migration tightens execute privileges by running `REVOKE EXECUTE ON FUNCTION public.get_following_feed(...) FROM PUBLIC;` and then `GRANT EXECUTE ... TO authenticated;`. 

### Testing
- Confirmed the vulnerable RPC definition was present with `rg -n "get_following_feed|harden_get_feed" supabase/migrations`, which succeeded. 
- Inspected the new migration file with `nl -ba supabase/migrations/20260504090000_harden_get_following_feed_rpc_auth.sql` to verify the checks and predicate changes, which succeeded. 
- Added and committed the migration with `git add` and `git commit -m "fix(db): harden get_following_feed auth checks"`, which produced a successful commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e36ea440832ab7347d5afebedc0c)