### PR TITLE
Fix SECURITY DEFINER IDOR in get_following_feed RPC

### DIFF
--- a/supabase/migrations/20260301000000_get_following_feed.sql
+++ b/supabase/migrations/20260301000000_get_following_feed.sql
@@ -24,7 +24,14 @@ STABLE
 SECURITY DEFINER
 SET search_path TO 'public'
 AS $$
+DECLARE
+  v_auth_user uuid := auth.uid();
+  v_limit int := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
 BEGIN
+  IF v_auth_user IS NULL OR v_auth_user <> p_user_id THEN
+    RAISE EXCEPTION USING MESSAGE = 'Unauthorized', ERRCODE = '42501';
+  END IF;
+
   RETURN QUERY
   SELECT
     p.id,
@@ -51,7 +58,7 @@ BEGIN
   )
   AND (p_cursor IS NULL OR p.created_at < p_cursor)
   ORDER BY p.created_at DESC
-  LIMIT p_limit;
+  LIMIT v_limit;
 END;
 $$;
 -- Allow authenticated users to call this function (runs under their session).


### PR DESCRIPTION
### Motivation
- Close an IDOR/privacy bypass where the `SECURITY DEFINER` RPC `public.get_following_feed` trusted a caller-supplied `p_user_id` and could bypass RLS to leak private posts and `daily_usage` data.
- Reduce the risk of bulk data exfiltration by clamping an unbounded `p_limit` parameter.

### Description
- Bind the caller session to a local variable with `v_auth_user := auth.uid()` and reject requests where `v_auth_user IS NULL OR v_auth_user <> p_user_id` using `RAISE EXCEPTION ... ERRCODE = '42501'` to prevent authenticated IDOR access.
- Clamp `p_limit` server-side with `v_limit := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100)` and use `LIMIT v_limit` to cap page sizes.
- Preserve the existing feed selection query and the `GRANT EXECUTE` to `authenticated` so intended client behavior is unchanged for legitimate callers.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e9278c8c832a9c1bd8ec362c594c)