### PR TITLE
fix(auth): cap CLI JWT refresh to original 30-day lifetime

### DIFF
--- a/apps/web/__tests__/unit/cli-auth.test.ts
+++ b/apps/web/__tests__/unit/cli-auth.test.ts
@@ -179,14 +179,34 @@ describe("cli-auth", () => {
     });
 
     it("does not extend lifetime beyond the original 30 days", () => {
+      const decodeExp = (token: string): number => {
+        const payloadB64 = token.split(".")[1]!;
+        const padded =
+          payloadB64 + "=".repeat((4 - (payloadB64.length % 4)) % 4);
+        return JSON.parse(
+          Buffer.from(
+            padded.replace(/-/g, "+").replace(/_/g, "/"),
+            "base64",
+          ).toString("utf-8"),
+        ).exp as number;
+      };
+
       const token = createCliToken("user-1", "alice");
+      const originalExp = decodeExp(token);
+
+      // Refresh once, a week into the token's life.
       vi.setSystemTime(new Date(Date.now() + 8 * 24 * 60 * 60 * 1000));
       const first = verifyCliTokenWithRefresh(`Bearer ${token}`);
       expect(first?.refreshedToken).toBeTypeOf("string");
 
+      // The refreshed token keeps the ORIGINAL absolute expiry: the 30-day
+      // window is anchored to first issuance, not pushed forward by the refresh.
+      expect(decodeExp(first!.refreshedToken!)).toBe(originalExp);
+
+      // Past the original 30-day window the refreshed token is rejected
+      // outright, so a leaked token can never be chained into a fresh lifetime.
       vi.setSystemTime(new Date(Date.now() + 23 * 24 * 60 * 60 * 1000));
-      const second = verifyCliTokenWithRefresh(`Bearer ${first!.refreshedToken!}`);
-      expect(second?.refreshedToken).toBeNull();
+      expect(verifyCliTokenWithRefresh(`Bearer ${first!.refreshedToken!}`)).toBeNull();
     });
 
     it("returns null for invalid tokens", () => {

--- a/apps/web/__tests__/unit/cli-auth.test.ts
+++ b/apps/web/__tests__/unit/cli-auth.test.ts
@@ -178,6 +178,17 @@ describe("cli-auth", () => {
       expect(result!.refreshedToken).toBeNull();
     });
 
+    it("does not extend lifetime beyond the original 30 days", () => {
+      const token = createCliToken("user-1", "alice");
+      vi.setSystemTime(new Date(Date.now() + 8 * 24 * 60 * 60 * 1000));
+      const first = verifyCliTokenWithRefresh(`Bearer ${token}`);
+      expect(first?.refreshedToken).toBeTypeOf("string");
+
+      vi.setSystemTime(new Date(Date.now() + 23 * 24 * 60 * 60 * 1000));
+      const second = verifyCliTokenWithRefresh(`Bearer ${first!.refreshedToken!}`);
+      expect(second?.refreshedToken).toBeNull();
+    });
+
     it("returns null for invalid tokens", () => {
       expect(verifyCliTokenWithRefresh("Bearer not.a.token")).toBeNull();
       expect(verifyCliTokenWithRefresh(null)).toBeNull();

--- a/apps/web/lib/api/cli-auth.ts
+++ b/apps/web/lib/api/cli-auth.ts
@@ -5,6 +5,7 @@ interface JwtPayload {
   username?: string;
   iat: number;
   exp: number;
+  oiat?: number;
 }
 
 /**
@@ -47,18 +48,21 @@ function sign(header: string, payload: string, secret: string): string {
 /**
  * Create a signed JWT for CLI authentication.
  */
-export function createCliToken(userId: string, username: string | null): string {
+export function createCliToken(userId: string, username: string | null, originalIat?: number): string {
   const secret = process.env.CLI_JWT_SECRET;
   if (!secret) throw new Error("CLI_JWT_SECRET not configured");
 
   const header = base64urlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const now = Math.floor(Date.now() / 1000);
+  const absoluteIat = originalIat ?? now;
+  const absoluteExpiry = absoluteIat + 30 * 24 * 60 * 60;
   const payload = base64urlEncode(
     JSON.stringify({
       sub: userId,
       username: username ?? undefined,
       iat: now,
-      exp: now + 30 * 24 * 60 * 60, // 30 days
+      oiat: originalIat,
+      exp: Math.min(now + 30 * 24 * 60 * 60, absoluteExpiry),
     }),
   );
   const signature = sign(header, payload, secret);
@@ -117,13 +121,21 @@ export function verifyCliTokenWithRefresh(authHeader: string | null): CliAuthRes
   if (!decoded) return null;
 
   const username = decoded.username ?? null;
-  const tokenAgeSeconds = Math.floor(Date.now() / 1000) - decoded.iat;
+  const now = Math.floor(Date.now() / 1000);
+  const originalIat = decoded.oiat ?? decoded.iat;
+  const tokenAgeSeconds = now - decoded.iat;
+  const absoluteAgeSeconds = now - originalIat;
   const refreshThresholdSeconds = TOKEN_REFRESH_AFTER_DAYS * 24 * 60 * 60;
+  const absoluteLifetimeSeconds = 30 * 24 * 60 * 60;
 
   let refreshedToken: string | null = null;
-  if (tokenAgeSeconds >= refreshThresholdSeconds && process.env.CLI_JWT_SECRET) {
+  if (
+    tokenAgeSeconds >= refreshThresholdSeconds &&
+    absoluteAgeSeconds < absoluteLifetimeSeconds &&
+    process.env.CLI_JWT_SECRET
+  ) {
     try {
-      refreshedToken = createCliToken(decoded.sub, username);
+      refreshedToken = createCliToken(decoded.sub, username, originalIat);
     } catch {
       // If we can't mint a refresh, the request still succeeds with the old
       // token. The user just won't get the rotation this round.


### PR DESCRIPTION
### Motivation
- The existing sliding refresh allowed CLI JWTs to be repeatedly reissued and chained past their original 30-day lifetime, making stolen or post-deletion tokens renewable indefinitely. 
- The goal is to retain the usability improvement (transparent token rotation for interactive users) while restoring an absolute cap on credential lifetime so refreshes cannot extend tokens forever.

### Description
- Added an `oiat` (original issued-at) claim and extended `createCliToken` to accept an optional `originalIat` so refreshed tokens preserve the original issuance anchor via `oiat` and do not push the absolute expiry forward. 
- Changed token creation to compute `exp` as the minimum of the normal 30-day expiry and the absolute expiry derived from `oiat`, and added the `oiat` field into the payload. 
- Updated `verifyCliTokenWithRefresh` to compute `originalIat` and `absoluteAgeSeconds` and only mint a refreshed token when the token is past the refresh threshold and still within the original 30-day lifetime, passing `originalIat` through when creating the refreshed token. 
- Added a unit test `does not extend lifetime beyond the original 30 days` in `apps/web/__tests__/unit/cli-auth.test.ts` to assert refreshed tokens cannot be chained past the initial 30-day window.

### Testing
- Added unit coverage in `apps/web/__tests__/unit/cli-auth.test.ts` that verifies refresh behavior and the new non-chainable lifetime guard. 
- Attempts to run the test file locally were blocked by the environment: `pnpm -C apps/web vitest __tests__/unit/cli-auth.test.ts` failed due to an unsupported package manager specification and `cd apps/web && bun x vitest __tests__/unit/cli-auth.test.ts` failed with npm registry access (HTTP 403), so tests could not be executed in this runner. 
- The change is minimal and focused to preserve existing routes and behavior while restoring a bounded token lifetime; unit tests were added to cover the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa629d0e44832aaee072d20235a3b5)