### PR TITLE
Gate onboarding completion on first sync

### DIFF
--- a/apps/web/__tests__/api/profile.test.ts
+++ b/apps/web/__tests__/api/profile.test.ts
@@ -8,6 +8,18 @@ vi.mock("@/lib/supabase/service", () => ({
   getServiceClient: vi.fn(),
 }));
 
+vi.mock("@/lib/email/send-welcome-email", () => ({
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/referral", () => ({
+  attributeReferral: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/analytics/server", () => ({
+  captureServerActivationEvent: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock("@/lib/constants/regions", () => ({
   COUNTRY_TO_REGION: {
     US: "north_america",
@@ -18,6 +30,8 @@ vi.mock("@/lib/constants/regions", () => ({
 
 import { GET as getPublicProfile } from "@/app/api/users/[username]/route";
 import { GET as getOwnProfile, PATCH } from "@/app/api/users/me/route";
+import { captureServerActivationEvent } from "@/lib/analytics/server";
+import { sendWelcomeEmail } from "@/lib/email/send-welcome-email";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { NextRequest } from "next/server";
@@ -349,6 +363,131 @@ describe("PATCH /api/users/me", () => {
 
     expect(res.status).toBe(200);
     expect(json.username).toBe("new_name");
+  });
+
+  it("does not complete onboarding before first sync is present", async () => {
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "u-1", email: "u1@example.com" } },
+          error: null,
+        }),
+      },
+    };
+    const updateMock = vi.fn();
+    const dailyUsageChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: null,
+        error: null,
+      }),
+    };
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === "daily_usage") return dailyUsageChain;
+        if (table === "users") return { update: updateMock };
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { onboarding_completed: true })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe("Sync your first session before completing onboarding");
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(sendWelcomeEmail).not.toHaveBeenCalled();
+    expect(captureServerActivationEvent).not.toHaveBeenCalled();
+  });
+
+  it("completes onboarding after first sync and captures activation", async () => {
+    const authClient: Record<string, any> = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "u-1", email: "u1@example.com" } },
+          error: null,
+        }),
+      },
+    };
+    const usageRow = {
+      id: "usage-1",
+      session_count: 2,
+      total_tokens: 2500,
+    };
+    const updatedProfile = {
+      id: "u-1",
+      username: "alice",
+      onboarding_completed: true,
+    };
+    const dailyUsageChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: usageRow,
+        error: null,
+      }),
+    };
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: updatedProfile,
+            error: null,
+          }),
+        }),
+      }),
+    });
+    const leaderboardChain = {
+      select: vi.fn().mockReturnThis(),
+      neq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === "daily_usage") return dailyUsageChain;
+        if (table === "users") return { update: updateMock };
+        if (table === "leaderboard_weekly") return leaderboardChain;
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    (createClient as any).mockResolvedValue(authClient);
+    (getServiceClient as any).mockReturnValue(db);
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/users/me", { onboarding_completed: true })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.onboarding_completed).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith({ onboarding_completed: true });
+    expect(sendWelcomeEmail).toHaveBeenCalledWith({
+      userId: "u-1",
+      email: "u1@example.com",
+      username: "alice",
+    });
+    expect(captureServerActivationEvent).toHaveBeenCalledWith({
+      event: "activation_completed",
+      distinctId: "u-1",
+      properties: expect.objectContaining({
+        surface: "onboarding",
+        activation_state: "activated",
+        is_authenticated: true,
+        session_count: 2,
+        total_tokens: 2500,
+        "$insert_id": "activation_completed:usage-1",
+      }),
+    });
   });
 
   it("validates username format", async () => {

--- a/apps/web/__tests__/api/usage-status.test.ts
+++ b/apps/web/__tests__/api/usage-status.test.ts
@@ -12,12 +12,38 @@ import { GET } from "@/app/api/usage/status/route";
 import { captureServerActivationEvent } from "@/lib/analytics/server";
 import { createClient } from "@/lib/supabase/server";
 
-function mockUsageRows(rows: unknown[]) {
-  const chain = {
+function mockUsageStatus({
+  latestUsage,
+  totals = { total_cost: 0, total_tokens: 0 },
+  latestPost = null,
+  latestUsageError = null,
+}: {
+  latestUsage: unknown;
+  totals?: unknown;
+  latestPost?: unknown;
+  latestUsageError?: unknown;
+}) {
+  const latestUsageChain = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
-    order: vi.fn().mockResolvedValue({
-      data: rows,
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: latestUsage,
+      error: latestUsageError,
+    }),
+  };
+  const latestPostChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: latestPost,
+      error: null,
+    }),
+  };
+  const rpcChain = {
+    single: vi.fn().mockResolvedValue({
+      data: totals,
       error: null,
     }),
   };
@@ -27,8 +53,15 @@ function mockUsageRows(rows: unknown[]) {
         data: { user: { id: "user-1" } },
       }),
     },
-    from: vi.fn(() => chain),
+    from: vi.fn((table: string) => {
+      if (table === "daily_usage") return latestUsageChain;
+      if (table === "posts") return latestPostChain;
+      throw new Error(`Unexpected table ${table}`);
+    }),
+    rpc: vi.fn(() => rpcChain),
   } as any);
+
+  return { latestUsageChain, latestPostChain, rpcChain };
 }
 
 describe("GET /api/usage/status", () => {
@@ -37,33 +70,48 @@ describe("GET /api/usage/status", () => {
   });
 
   it("does not activate users without usage", async () => {
-    mockUsageRows([]);
+    const { latestUsageChain } = mockUsageStatus({ latestUsage: null });
 
     const res = await GET();
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json).toEqual({ has_data: false });
+    expect(json).toEqual({ has_data: false, has_usage: false });
+    expect(latestUsageChain.limit).toHaveBeenCalledWith(1);
     expect(captureServerActivationEvent).not.toHaveBeenCalled();
   });
 
   it("captures first sync confirmation when web observes usage", async () => {
-    mockUsageRows([
-      {
+    mockUsageStatus({
+      latestUsage: {
         id: "usage-1",
         date: "2026-07-02",
+        created_at: "2026-07-02T10:00:00.000Z",
         cost_usd: 1.25,
         total_tokens: 2500,
+        output_tokens: 1200,
         session_count: 2,
         models: ["claude-sonnet-4-5-20250929"],
       },
-    ]);
+      totals: {
+        total_cost: 7.75,
+        total_tokens: 9000,
+      },
+      latestPost: { id: "post-1" },
+    });
 
     const res = await GET();
     const json = await res.json();
 
     expect(res.status).toBe(200);
     expect(json.has_data).toBe(true);
+    expect(json.has_usage).toBe(true);
+    expect(json.cost_usd).toBe(7.75);
+    expect(json.total_tokens).toBe(9000);
+    expect(json.session_count).toBe(2);
+    expect(json.latest_usage_id).toBe("usage-1");
+    expect(json.latest_usage_at).toBe("2026-07-02T10:00:00.000Z");
+    expect(json.latest_post_url).toBe("/post/post-1");
     expect(captureServerActivationEvent).toHaveBeenCalledWith({
       event: "first_sync_confirmed",
       distinctId: "user-1",
@@ -72,8 +120,8 @@ describe("GET /api/usage/status", () => {
         activation_state: "activated",
         is_authenticated: true,
         session_count: 2,
-        total_tokens: 2500,
-        total_cost_usd: 1.25,
+        total_tokens: 9000,
+        total_cost_usd: 7.75,
         "$insert_id": "first_sync_confirmed:user-1:usage-1",
       }),
     });

--- a/apps/web/app/(onboarding)/onboarding/page.tsx
+++ b/apps/web/app/(onboarding)/onboarding/page.tsx
@@ -7,8 +7,6 @@ import { BoltIcon } from "@/components/landing/icons";
 import { Check, X, Loader2, ArrowRight, Copy } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
-import { Textarea } from "@/components/ui/Textarea";
-import { CountryPicker } from "@/components/ui/CountryPicker";
 import { trackActivationEvent } from "@/lib/analytics/client";
 import { formatCurrency } from "@/lib/utils/format";
 
@@ -16,10 +14,14 @@ const SYNC_COMMAND = "npx straude@latest";
 
 interface UsageStatus {
   has_data: boolean;
+  has_usage?: boolean;
   cost_usd?: number;
   total_tokens?: number;
   session_count?: number;
   top_model?: string | null;
+  latest_usage_id?: string;
+  latest_usage_at?: string | null;
+  latest_post_url?: string | null;
 }
 
 function formatTokens(n: number): string {
@@ -33,10 +35,15 @@ function Step3LogSession({ username }: { username: string }) {
   const [copied, setCopied] = useState(false);
   const [phase, setPhase] = useState<"waiting" | "success">("waiting");
   const [data, setData] = useState<UsageStatus | null>(null);
+  const [hasExistingUsage, setHasExistingUsage] = useState(false);
+  const [completionError, setCompletionError] = useState<string | null>(null);
   const activationTrackedRef = useRef(false);
+  const activationPersistedRef = useRef(false);
+  const commandCopiedRef = useRef(false);
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(SYNC_COMMAND).then(() => {
+      commandCopiedRef.current = true;
       trackActivationEvent("sync_command_copied", {
         surface: "onboarding",
         command: SYNC_COMMAND,
@@ -48,9 +55,7 @@ function Step3LogSession({ username }: { username: string }) {
     });
   }, []);
 
-  // Poll for NEW session data (ignore pre-existing usage)
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
-  const baselineRef = useRef<number | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -60,29 +65,12 @@ function Step3LogSession({ username }: { username: string }) {
         const res = await fetch("/api/usage/status");
         if (!res.ok) return;
         const json: UsageStatus = await res.json();
-        const count = json.session_count ?? 0;
+        const hasUsage = json.has_usage ?? json.has_data;
 
-        // First poll: record the baseline
-        if (baselineRef.current === null) {
-          baselineRef.current = count;
-          return;
-        }
-
-        // Only transition when sessions increase beyond baseline
-        if (count > baselineRef.current && active) {
+        if (hasUsage && active) {
           setData(json);
+          setHasExistingUsage(!commandCopiedRef.current);
           setPhase("success");
-          if (!activationTrackedRef.current) {
-            activationTrackedRef.current = true;
-            trackActivationEvent("activation_completed", {
-              surface: "onboarding",
-              activation_state: "activated",
-              is_authenticated: true,
-              session_count: count,
-              total_tokens: json.total_tokens,
-              total_cost_usd: json.cost_usd,
-            });
-          }
           if (intervalRef.current) clearInterval(intervalRef.current);
         }
       } catch {
@@ -97,6 +85,49 @@ function Step3LogSession({ username }: { username: string }) {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (phase !== "success" || !data || activationPersistedRef.current) return;
+
+    activationPersistedRef.current = true;
+    const observedUsage = data;
+
+    async function persistActivation() {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ onboarding_completed: true }),
+      });
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        setCompletionError(
+          typeof payload.error === "string"
+            ? payload.error
+            : "We saw your usage, but setup could not be completed. Refresh and try again.",
+        );
+        return;
+      }
+
+      if (!activationTrackedRef.current) {
+        activationTrackedRef.current = true;
+        trackActivationEvent("activation_completed", {
+          surface: "onboarding",
+          activation_state: "activated",
+          is_authenticated: true,
+          session_count: observedUsage.session_count,
+          total_tokens: observedUsage.total_tokens,
+          total_cost_usd: observedUsage.cost_usd,
+          has_existing_usage: hasExistingUsage,
+          "$insert_id": observedUsage.latest_usage_id
+            ? `activation_completed:${observedUsage.latest_usage_id}`
+            : "activation_completed:onboarding",
+        });
+      }
+    }
+
+    void persistActivation();
+  }, [data, hasExistingUsage, phase]);
 
   if (phase === "success" && data) {
     return (
@@ -115,7 +146,8 @@ function Step3LogSession({ username }: { username: string }) {
           </h1>
         </div>
         <p className="mb-6 text-sm text-muted">
-          Your usage is live. Here&apos;s what we captured.
+          Your usage is live. Straude can now build your streak, spend totals,
+          and shareable session history.
         </p>
 
         {/* Stats grid */}
@@ -146,7 +178,23 @@ function Step3LogSession({ username }: { username: string }) {
           </div>
         </div>
 
+        {completionError && (
+          <p className="mt-4 rounded border border-red-500/30 bg-red-500/5 px-3 py-2 text-sm text-red-500">
+            {completionError}
+          </p>
+        )}
+
         <div className="mt-6 flex items-center gap-3">
+          {data.latest_post_url && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => router.push(data.latest_post_url ?? "/feed")}
+              className="py-3"
+            >
+              View session
+            </Button>
+          )}
           <Button
             onClick={() => router.push(username ? `/u/${username}` : "/feed")}
             className="flex-1 py-3"
@@ -176,11 +224,11 @@ function Step3LogSession({ username }: { username: string }) {
         className="text-2xl font-medium tracking-tight"
         style={{ letterSpacing: "-0.03em" }}
       >
-        Log your first session
+        Sync your first session
       </h1>
       <p className="mt-1 mb-6 text-sm text-muted">
-        Run this in your terminal to post today&apos;s Claude Code usage to your
-        profile. Takes about 10 seconds.
+        Run this in your terminal after a Claude Code or Codex session. Straude
+        will post your usage stats as soon as the web app sees them.
       </p>
 
       {/* Copy-to-clipboard command */}
@@ -203,7 +251,7 @@ function Step3LogSession({ username }: { username: string }) {
 
       {/* Privacy assurance */}
       <p className="mt-4 text-xs leading-relaxed text-muted">
-        Only aggregate stats leave your machine — token counts, cost, model
+        Only aggregate stats leave your machine - token counts, cost, model
         names. Your prompts, code, and conversations never do.{" "}
         <Link href="/privacy" className="underline underline-offset-2 hover:text-foreground">
           Privacy policy
@@ -222,7 +270,7 @@ function Step3LogSession({ username }: { username: string }) {
           variant="secondary"
           className="flex-1 py-3"
         >
-          I&apos;ll do this later
+          Explore without syncing
         </Button>
       </div>
 
@@ -248,12 +296,6 @@ export default function OnboardingPage() {
   const [usernameStatus, setUsernameStatus] = useState<UsernameStatus>("idle");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Step 2
-  const [bio, setBio] = useState("");
-  const [heardAbout, setHeardAbout] = useState("");
-  const [country, setCountry] = useState("");
-  const [githubUsername, setGithubUsername] = useState("");
-
   // Auto-detect timezone
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
@@ -263,9 +305,6 @@ export default function OnboardingPage() {
       const res = await fetch("/api/users/me");
       if (res.ok) {
         const profile = await res.json();
-        if (profile.github_username) {
-          setGithubUsername(profile.github_username);
-        }
         // Pre-fill username: use existing username (e.g. auto-claimed from GitHub),
         // otherwise suggest from GitHub handle
         if (profile.username) {
@@ -281,9 +320,6 @@ export default function OnboardingPage() {
           }
         }
         if (profile.display_name) setDisplayName(profile.display_name);
-        if (profile.country) setCountry(profile.country);
-        if (profile.bio) setBio(profile.bio);
-        if (profile.heard_about) setHeardAbout(profile.heard_about);
       }
     }
     loadProfile();
@@ -319,20 +355,15 @@ export default function OnboardingPage() {
     };
   }, [username]);
 
-  async function handleFinish() {
+  async function handleProfileSave() {
     setSaving(true);
     setError(null);
 
     const body: Record<string, unknown> = {
       timezone,
-      onboarding_completed: true,
     };
     if (username) body.username = username;
     if (displayName) body.display_name = displayName;
-    if (bio) body.bio = bio;
-    body.heard_about = heardAbout.trim() || null;
-    if (country) body.country = country;
-    if (githubUsername) body.github_username = githubUsername;
 
     const res = await fetch("/api/users/me", {
       method: "PATCH",
@@ -347,6 +378,7 @@ export default function OnboardingPage() {
       return;
     }
 
+    setSaving(false);
     setStep(3);
   }
 
@@ -449,12 +481,6 @@ export default function OnboardingPage() {
           </Button>
         </div>
 
-        <div className="mt-3 text-center">
-          <Link href="/feed" className="text-sm text-muted hover:text-foreground">
-            Skip for now
-          </Link>
-        </div>
-
         <div className="mt-4 flex justify-center gap-1.5">
           <span className="h-1.5 w-6 rounded-full bg-accent" />
           <span className="h-1.5 w-6 rounded-full bg-border" />
@@ -475,74 +501,25 @@ export default function OnboardingPage() {
           className="text-2xl font-medium tracking-tight"
           style={{ letterSpacing: "-0.03em" }}
         >
-          Almost there
+          Ready to sync
         </h1>
         <p className="mt-1 mb-6 text-sm text-muted">
-          Optional details to round out your profile. You can always change these
-          later in Settings.
+          Your first sync unlocks the useful parts of Straude: spend, tokens,
+          streaks, and a shareable session you can edit after it lands.
         </p>
 
-        <div className="space-y-4">
-          <div>
-            <label htmlFor="onboard-bio" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-muted">
-              Bio
-            </label>
-            <Textarea
-              id="onboard-bio"
-              name="bio"
-              value={bio}
-              onChange={(e) => setBio(e.target.value)}
-              placeholder="What are you building with Claude\u2026"
-              maxLength={160}
-              rows={2}
-              className="min-h-0"
-            />
-            <p className="mt-1 text-xs text-muted">{bio.length}/160</p>
+        <div className="space-y-3 rounded border border-border bg-subtle px-4 py-4 text-sm text-muted">
+          <div className="flex gap-3">
+            <Check size={16} className="mt-0.5 shrink-0 text-accent" aria-hidden="true" />
+            <p>One command posts aggregate usage for your latest local sessions.</p>
           </div>
-
-          <div>
-            <label htmlFor="onboard-heard-about" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-muted">
-              How did you hear about us?
-            </label>
-            <Textarea
-              id="onboard-heard-about"
-              name="heard_about"
-              value={heardAbout}
-              onChange={(e) => setHeardAbout(e.target.value)}
-              placeholder="Friend, GitHub, X, newsletter, podcast..."
-              maxLength={500}
-              rows={3}
-              className="min-h-0"
-              aria-describedby="onboard-heard-about-hint"
-            />
-            <div className="mt-1 flex items-end justify-end text-xs text-muted">
-              <span>{heardAbout.length}/500</span>
-            </div>
+          <div className="flex gap-3">
+            <Check size={16} className="mt-0.5 shrink-0 text-accent" aria-hidden="true" />
+            <p>Prompts, code, file paths, and conversation text stay private.</p>
           </div>
-
-          <div>
-            <label htmlFor="onboard-country" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-muted">
-              Country
-            </label>
-            <CountryPicker
-              id="onboard-country"
-              name="country"
-              value={country}
-              onChange={setCountry}
-            />
-          </div>
-
-          <div>
-            <label htmlFor="onboard-github" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-muted">
-              GitHub username
-            </label>
-            <Input
-              id="onboard-github"
-              name="github_username"
-              value={githubUsername}
-              onChange={(e) => setGithubUsername(e.target.value)}
-              placeholder="your-github"
-            />
+          <div className="flex gap-3">
+            <Check size={16} className="mt-0.5 shrink-0 text-accent" aria-hidden="true" />
+            <p>You can add bio, location, and links later from Settings.</p>
           </div>
         </div>
 
@@ -557,18 +534,12 @@ export default function OnboardingPage() {
             Back
           </button>
           <Button
-            onClick={handleFinish}
+            onClick={handleProfileSave}
             disabled={saving}
             className="flex-1 py-3"
           >
-            {saving ? "Setting up\u2026" : "Start logging"}
+            {saving ? "Saving..." : "Show sync command"}
           </Button>
-        </div>
-
-        <div className="mt-3 text-center">
-          <Link href="/feed" className="text-sm text-muted hover:text-foreground">
-            Skip for now
-          </Link>
         </div>
 
         <div className="mt-4 flex justify-center gap-1.5">

--- a/apps/web/app/api/usage/status/route.ts
+++ b/apps/web/app/api/usage/status/route.ts
@@ -3,6 +3,26 @@ import { after } from "@/lib/utils/after";
 import { captureServerActivationEvent } from "@/lib/analytics/server";
 import { createClient } from "@/lib/supabase/server";
 
+type LatestUsageRow = {
+  id: string;
+  date: string;
+  cost_usd: number | string | null;
+  total_tokens: number | string | null;
+  session_count: number | string | null;
+  models: unknown;
+  created_at: string | null;
+};
+
+type UsageTotalsRow = {
+  total_cost: number | string | null;
+  total_tokens: number | string | null;
+};
+
+function firstModel(models: unknown): string | null {
+  if (!Array.isArray(models) || models.length === 0) return null;
+  return typeof models[0] === "string" ? models[0] : null;
+}
+
 export async function GET() {
   const supabase = await createClient();
   const {
@@ -13,31 +33,43 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Fetch aggregated usage
-  const { data: usageRows, error: usageError } = await supabase
-    .from("daily_usage")
-    .select("id,date,cost_usd,total_tokens,session_count,models")
-    .eq("user_id", user.id)
-    .order("date", { ascending: false });
+  const [latestUsageResult, usageTotalsResult] = await Promise.all([
+    supabase
+      .from("daily_usage")
+      .select("id,date,cost_usd,total_tokens,session_count,models,created_at")
+      .eq("user_id", user.id)
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .rpc("get_user_usage_totals", { p_user_id: user.id })
+      .single(),
+  ]);
 
-  if (usageError) {
+  if (latestUsageResult.error) {
     return NextResponse.json({ error: "Failed to fetch usage" }, { status: 500 });
   }
 
-  if (!usageRows || usageRows.length === 0) {
-    return NextResponse.json({ has_data: false });
+  const latestUsage = latestUsageResult.data as LatestUsageRow | null;
+
+  if (!latestUsage) {
+    return NextResponse.json({ has_data: false, has_usage: false });
   }
 
-  const cost_usd = usageRows.reduce((sum, r) => sum + Number(r.cost_usd), 0);
-  const total_tokens = usageRows.reduce((sum, r) => sum + Number(r.total_tokens), 0);
-  const session_count = usageRows.reduce((sum, r) => sum + Number(r.session_count), 0);
+  const totals = usageTotalsResult.data as UsageTotalsRow | null;
+  const cost_usd = usageTotalsResult.error
+    ? Number(latestUsage.cost_usd ?? 0)
+    : Number(totals?.total_cost ?? latestUsage.cost_usd ?? 0);
+  const total_tokens = usageTotalsResult.error
+    ? Number(latestUsage.total_tokens ?? 0)
+    : Number(totals?.total_tokens ?? latestUsage.total_tokens ?? 0);
+  const session_count = Number(latestUsage.session_count ?? 0);
 
-  // Top model from most recent row
-  const top_model =
-    Array.isArray(usageRows[0].models) && usageRows[0].models.length > 0
-      ? usageRows[0].models[0]
-      : null;
-  const latestUsage = usageRows[0];
+  const { data: latestPost } = await supabase
+    .from("posts")
+    .select("id")
+    .eq("daily_usage_id", latestUsage.id)
+    .maybeSingle();
 
   after(() => captureServerActivationEvent({
     event: "first_sync_confirmed",
@@ -49,15 +81,20 @@ export async function GET() {
       session_count,
       total_tokens,
       total_cost_usd: Math.round(cost_usd * 100) / 100,
-      "$insert_id": `first_sync_confirmed:${user.id}:${latestUsage.id ?? latestUsage.date}`,
+      "$insert_id": `first_sync_confirmed:${user.id}:${latestUsage.id}`,
     },
   }));
 
   return NextResponse.json({
     has_data: true,
+    has_usage: true,
     cost_usd: Math.round(cost_usd * 100) / 100,
     total_tokens,
     session_count,
-    top_model,
+    top_model: firstModel(latestUsage.models),
+    latest_usage_id: latestUsage.id,
+    latest_usage_at: latestUsage.created_at ?? latestUsage.date,
+    latest_usage_date: latestUsage.date,
+    latest_post_url: latestPost?.id ? `/post/${latestPost.id}` : null,
   });
 }

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { after } from "@/lib/utils/after";
+import { captureServerActivationEvent } from "@/lib/analytics/server";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { COUNTRY_TO_REGION } from "@/lib/constants/regions";
@@ -25,6 +27,12 @@ const ALLOWED_FIELDS = [
 
 const BIO_MAX_LENGTH = 160;
 const HEARD_ABOUT_MAX_LENGTH = 500;
+
+type ActivationUsageRow = {
+  id: string;
+  session_count: number | string | null;
+  total_tokens: number | string | null;
+};
 
 function normalizeProfileLink(value: unknown): string | null {
   if (value === null) return null;
@@ -199,9 +207,36 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: "No fields to update" }, { status: 400 });
   }
 
-  const isOnboardingUpdate = updates.onboarding_completed === true;
-
   const db = getServiceClient();
+  const isOnboardingUpdate = updates.onboarding_completed === true;
+  let activationUsage: ActivationUsageRow | null = null;
+
+  if (isOnboardingUpdate) {
+    const { data: usageRow, error: usageError } = await db
+      .from("daily_usage")
+      .select("id,session_count,total_tokens")
+      .eq("user_id", user.id)
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (usageError) {
+      return NextResponse.json(
+        { error: "Unable to verify first sync" },
+        { status: 500 },
+      );
+    }
+
+    if (!usageRow) {
+      return NextResponse.json(
+        { error: "Sync your first session before completing onboarding" },
+        { status: 409 },
+      );
+    }
+
+    activationUsage = usageRow as ActivationUsageRow;
+  }
+
   const { data: profile, error } = await db
     .from("users")
     .update(updates)
@@ -233,6 +268,21 @@ export async function PATCH(request: NextRequest) {
 
   // Auto-follow top active users so new users see content in their feed
   if (isOnboardingUpdate) {
+    after(() => captureServerActivationEvent({
+      event: "activation_completed",
+      distinctId: user.id,
+      properties: {
+        surface: "onboarding",
+        activation_state: "activated",
+        is_authenticated: true,
+        session_count: Number(activationUsage?.session_count ?? 0),
+        total_tokens: Number(activationUsage?.total_tokens ?? 0),
+        "$insert_id": activationUsage?.id
+          ? `activation_completed:${activationUsage.id}`
+          : `activation_completed:${user.id}`,
+      },
+    }));
+
     autoFollowTopUsers(user.id).catch(() => {});
 
     // Attribute referral from cookie


### PR DESCRIPTION
## Summary
- simplifies onboarding so profile setup leads directly to the sync command
- requires observed daily usage before onboarding can be marked complete
- optimizes usage status polling to fetch the latest usage row plus aggregate totals instead of every daily usage row
- returns the latest session URL so activated users can jump straight to their first synced session

## Verification
- bun --cwd apps/web test -- __tests__/api/usage-status.test.ts __tests__/api/profile.test.ts __tests__/flows/activation-contract.test.ts
- bun --cwd apps/web typecheck
- bun --cwd apps/web build