### PR TITLE
Speed up public landing pages

### DIFF
--- a/apps/web/__tests__/lib/open-stats.test.ts
+++ b/apps/web/__tests__/lib/open-stats.test.ts
@@ -3,6 +3,7 @@ import {
   type OpenStats,
   type OpenStatsDb,
   getOpenStatsForPage,
+  refreshOpenStatsSnapshot,
 } from "@/lib/open-stats";
 
 type FixtureOptions = {
@@ -116,6 +117,61 @@ afterEach(() => {
 });
 
 describe("getOpenStatsForPage", () => {
+  it("returns the latest snapshot without running live aggregation", async () => {
+    const snapshotStats = makeSnapshotStats({
+      totalSpend: 101_001,
+      snapshotDate: "2026-03-31",
+      fetchedAt: "2026-03-31T23:59:59.000Z",
+    });
+    const { db, snapshotUpsert } = makeDb({
+      snapshotRows: [
+        {
+          snapshot_date: "2026-03-31",
+          captured_at: "2026-03-31T23:59:59.000Z",
+          stats: snapshotStats,
+        },
+      ],
+    });
+
+    const stats = await getOpenStatsForPage(db);
+
+    expect(stats.source).toBe("snapshot");
+    expect(stats.totalSpend).toBe(101_001);
+    expect(stats.snapshotDate).toBe("2026-03-31");
+    expect(db.from).not.toHaveBeenCalledWith("daily_usage");
+    expect(db.rpc).not.toHaveBeenCalled();
+    expect(snapshotUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns placeholder stats when the snapshot read fails", async () => {
+    const { db } = makeDb({
+      snapshotError: { message: "connection refused" },
+    });
+
+    const stats = await getOpenStatsForPage(db);
+
+    expect(stats.source).toBe("snapshot");
+    expect(stats.totalSpend).toBe(0);
+    expect(stats.trackedUsers).toBe(0);
+    expect(stats.models).toEqual([]);
+    expect(db.from).not.toHaveBeenCalledWith("daily_usage");
+    expect(db.rpc).not.toHaveBeenCalled();
+  });
+
+  it("returns placeholder stats when no snapshot exists", async () => {
+    const { db } = makeDb({ snapshotRows: [] });
+
+    const stats = await getOpenStatsForPage(db);
+
+    expect(stats.source).toBe("snapshot");
+    expect(stats.totalSpend).toBe(0);
+    expect(stats.trackedUsers).toBe(0);
+    expect(db.from).not.toHaveBeenCalledWith("daily_usage");
+    expect(db.rpc).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshOpenStatsSnapshot", () => {
   it("returns live stats and writes the latest snapshot", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-01T12:00:00.000Z"));
@@ -143,7 +199,7 @@ describe("getOpenStatsForPage", () => {
       spendRows: [{ date: "2026-04-01", daily_total: 12.5, cumulative_total: 12.5 }],
     });
 
-    const stats = await getOpenStatsForPage(db);
+    const stats = await refreshOpenStatsSnapshot(db);
 
     expect(stats.source).toBe("live");
     expect(stats.totalSpend).toBe(12.5);
@@ -159,64 +215,25 @@ describe("getOpenStatsForPage", () => {
     );
   });
 
-  it("falls back to the latest snapshot when the live query fails", async () => {
-    const snapshotStats = makeSnapshotStats();
-    const { db, snapshotUpsert } = makeDb({
-      usageError: { message: "database offline" },
-      snapshotRows: [
-        {
-          snapshot_date: "2026-04-01",
-          captured_at: "2026-04-01T12:00:00.000Z",
-          stats: snapshotStats,
-        },
-      ],
-    });
-
-    const stats = await getOpenStatsForPage(db);
-
-    expect(stats.source).toBe("snapshot");
-    expect(stats.totalSpend).toBe(snapshotStats.totalSpend);
-    expect(stats.fetchedAt).toBe(snapshotStats.fetchedAt);
-    expect(snapshotUpsert).not.toHaveBeenCalled();
-  });
-
-  it("returns placeholder stats when both live and snapshot fail", async () => {
+  it("throws when the live query fails", async () => {
     const { db } = makeDb({
-      usageError: { message: "connection refused" },
-      snapshotError: { message: "connection refused" },
+      usageError: { message: "database offline" },
     });
 
-    const stats = await getOpenStatsForPage(db);
-
-    expect(stats.source).toBe("snapshot");
-    expect(stats.totalSpend).toBe(0);
-    expect(stats.trackedUsers).toBe(0);
-    expect(stats.models).toEqual([]);
+    await expect(refreshOpenStatsSnapshot(db)).rejects.toThrow(
+      "open stats daily_usage query failed",
+    );
   });
 
-  it("falls back to the latest snapshot when live stats come back empty", async () => {
-    const snapshotStats = makeSnapshotStats({
-      totalSpend: 101_001,
-      snapshotDate: "2026-03-31",
-      fetchedAt: "2026-03-31T23:59:59.000Z",
-    });
+  it("throws when live stats come back empty", async () => {
     const { db } = makeDb({
       usageRows: [],
       concentrationRows: [],
       growthRows: [],
-      snapshotRows: [
-        {
-          snapshot_date: "2026-03-31",
-          captured_at: "2026-03-31T23:59:59.000Z",
-          stats: snapshotStats,
-        },
-      ],
     });
 
-    const stats = await getOpenStatsForPage(db);
-
-    expect(stats.source).toBe("snapshot");
-    expect(stats.totalSpend).toBe(101_001);
-    expect(stats.snapshotDate).toBe("2026-03-31");
+    await expect(refreshOpenStatsSnapshot(db)).rejects.toThrow(
+      "open stats daily_usage query returned no rows",
+    );
   });
 });

--- a/apps/web/app/(landing)/open/page.tsx
+++ b/apps/web/app/(landing)/open/page.tsx
@@ -164,9 +164,7 @@ export default async function OpenStatsPage() {
             Daily, anonymized data from the Straude community.
           </p>
           <p className="mt-2 text-sm text-muted">
-            {stats.source === "snapshot"
-              ? "Showing the last successful snapshot while the live refresh recovers."
-              : "Updated daily from the latest successful Straude snapshot."}
+            Updated daily from the latest successful Straude snapshot.
           </p>
 
           {/* ---- Big Number Grid ----------------------------------------- */}

--- a/apps/web/components/landing/CTASection.tsx
+++ b/apps/web/components/landing/CTASection.tsx
@@ -1,3 +1,10 @@
+import {
+  CopyCommandButton,
+  SignupCtaLink,
+} from "@/components/landing/LandingActivationActions";
+import { ProductHuntBadge } from "@/components/landing/ProductHuntBadge";
+import { LANDING_SYNC_COMMAND } from "@/components/landing/constants";
+
 export function CTASection() {
   return (
     <section className="border-t border-landing-border py-24 md:py-32">
@@ -10,16 +17,25 @@ export function CTASection() {
         <div className="font-[family-name:var(--font-mono)] text-sm text-landing-muted">
           1. Claim your profile at straude.com
           <br />
-          2. Run one command after your session
+          2. Run one command after your first session
           <br />
-          3. See who else is putting in the work
+          3. Watch Straude confirm the sync
         </div>
-        <div className="inline-flex items-center gap-4 border border-landing-border bg-landing-panel px-6 py-3 font-[family-name:var(--font-mono)] text-lg text-landing-muted">
-          ${" "}
-          <span className="text-landing-text">
-            npx straude push --days 7
-          </span>
+
+        <div className="flex flex-col items-center gap-3 sm:flex-row">
+          <SignupCtaLink
+            ctaLocation="final_primary"
+            className="inline-flex items-center justify-center border border-accent bg-accent px-8 py-4 font-[family-name:var(--font-mono)] text-sm font-bold uppercase text-landing-bg transition-all duration-200 hover:bg-transparent hover:text-accent active:scale-[0.97]"
+          >
+            Start Your Streak
+          </SignupCtaLink>
+          <CopyCommandButton
+            command={LANDING_SYNC_COMMAND}
+            className="inline-flex cursor-pointer items-center gap-4 border border-landing-border bg-landing-panel px-6 py-4 font-[family-name:var(--font-mono)] text-sm text-landing-muted transition-[border-color,transform] hover:border-landing-dim active:scale-[0.97]"
+          />
         </div>
+
+        <ProductHuntBadge />
       </div>
     </section>
   );

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -1,61 +1,13 @@
-"use client";
-
-import Link from "next/link";
-import { useCallback, useState } from "react";
-import { ProductHuntBadge } from "./ProductHuntBadge";
-import { trackActivationEvent } from "@/lib/analytics/client";
-
-const SYNC_COMMAND = "npx straude@latest";
-
-function CopySnippet({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = useCallback(() => {
-    navigator.clipboard.writeText(command).then(() => {
-      trackActivationEvent("sync_command_copied", {
-        surface: "landing",
-        command,
-        activation_state: "sync_command_copied",
-        is_authenticated: false,
-      });
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }, [command]);
-
-  return (
-    <button
-      onClick={copy}
-      className="inline-flex cursor-pointer items-center gap-4 border border-landing-border bg-landing-panel px-4 py-3 font-[family-name:var(--font-mono)] text-sm text-landing-muted transition-[border-color,transform] hover:border-landing-dim active:scale-[0.97]"
-    >
-      ${" "}
-      <span className="text-landing-text">{command}</span>
-      {copied && (
-        <svg
-          className="h-4 w-4 text-accent"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M5 13l4 4L19 7"
-          />
-        </svg>
-      )}
-    </button>
-  );
-}
+import {
+  CopyCommandButton,
+  SignupCtaLink,
+} from "@/components/landing/LandingActivationActions";
+import { LANDING_SYNC_COMMAND } from "@/components/landing/constants";
 
 export function Hero() {
   return (
     <header className="min-h-screen flex flex-col justify-center px-8 lg:px-16 pt-32 relative">
       <div className="max-w-[900px]">
-        <div className="mb-6">
-          <ProductHuntBadge />
-        </div>
         <p className="font-[family-name:var(--font-mono)] text-sm uppercase tracking-wider text-landing-muted mb-4">
           {"// STRAVA FOR CLAUDE CODE"}
         </p>
@@ -72,26 +24,19 @@ export function Hero() {
         </p>
 
         <div className="flex flex-wrap gap-4 mt-10">
-          <Link
-            href="/signup"
-            onClick={() => trackActivationEvent("landing_primary_cta_clicked", {
-              surface: "landing",
-              cta_location: "hero_primary",
-              destination: "/signup",
-              activation_state: "anonymous",
-              is_authenticated: false,
-            })}
+          <SignupCtaLink
+            ctaLocation="hero_primary"
             className="inline-flex items-center justify-center bg-accent text-landing-bg font-[family-name:var(--font-mono)] text-sm font-bold uppercase px-8 py-4 border border-accent hover:bg-transparent hover:text-accent active:scale-[0.97] transition-all duration-200"
           >
             Start Your Streak
-          </Link>
-          <CopySnippet command={SYNC_COMMAND} />
+          </SignupCtaLink>
+          <CopyCommandButton command={LANDING_SYNC_COMMAND} />
         </div>
 
         {/* Terminal output */}
         <div className="mt-10 font-[family-name:var(--font-mono)] text-[0.8rem] text-landing-muted leading-relaxed max-w-[600px]">
           <span className="block text-landing-text">
-            &gt; {SYNC_COMMAND}
+            &gt; {LANDING_SYNC_COMMAND}
           </span>
           <span className="block">Analyzing ~/.config/claude/projects/...</span>
           <span className="block">
@@ -106,7 +51,7 @@ export function Hero() {
             Est. Cost: <span className="text-accent">$19.93</span>
           </span>
           <span className="block text-accent">
-            [OK] Session logged. Current streak: 18 days {"🔥"}
+            [OK] Session logged. Current streak: 18 days
           </span>
         </div>
       </div>

--- a/apps/web/components/landing/LandingActivationActions.tsx
+++ b/apps/web/components/landing/LandingActivationActions.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useState } from "react";
+import { Check } from "lucide-react";
+import { trackActivationEvent } from "@/lib/analytics/client";
+import { LANDING_SYNC_COMMAND } from "@/components/landing/constants";
+
+export function SignupCtaLink({
+  children,
+  className,
+  ctaLocation,
+}: {
+  children: React.ReactNode;
+  className: string;
+  ctaLocation: string;
+}) {
+  return (
+    <Link
+      href="/signup"
+      onClick={() =>
+        trackActivationEvent("landing_primary_cta_clicked", {
+          surface: "landing",
+          cta_location: ctaLocation,
+          destination: "/signup",
+          activation_state: "anonymous",
+          is_authenticated: false,
+        })
+      }
+      className={className}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function CopyCommandButton({
+  command = LANDING_SYNC_COMMAND,
+  className,
+}: {
+  command?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(() => {
+    navigator.clipboard.writeText(command).then(() => {
+      trackActivationEvent("sync_command_copied", {
+        surface: "landing",
+        command,
+        activation_state: "sync_command_copied",
+        is_authenticated: false,
+      });
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    });
+  }, [command]);
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className={
+        className ??
+        "inline-flex cursor-pointer items-center gap-4 border border-landing-border bg-landing-panel px-4 py-3 font-[family-name:var(--font-mono)] text-sm text-landing-muted transition-[border-color,transform] hover:border-landing-dim active:scale-[0.97]"
+      }
+    >
+      ${" "}
+      <span className="text-landing-text">{command}</span>
+      {copied && (
+        <Check className="h-4 w-4 text-accent" aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/apps/web/components/landing/LazyHalftoneCanvas.tsx
+++ b/apps/web/components/landing/LazyHalftoneCanvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 
 const HalftoneCanvas = dynamic(
   () =>
@@ -11,5 +12,38 @@ const HalftoneCanvas = dynamic(
 );
 
 export function LazyHalftoneCanvas() {
-  return <HalftoneCanvas />;
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    const saveData =
+      "connection" in navigator &&
+      Boolean((navigator as Navigator & { connection?: { saveData?: boolean } }).connection?.saveData);
+
+    if (prefersReducedMotion || saveData) return;
+
+    const start = () => setEnabled(true);
+    if ("requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(start, { timeout: 1800 });
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = globalThis.setTimeout(start, 1200);
+    return () => globalThis.clearTimeout(timeoutId);
+  }, []);
+
+  return (
+    <>
+      <div
+        className="pointer-events-none fixed inset-0 z-0 opacity-35"
+        aria-hidden="true"
+      >
+        <div className="h-full w-full bg-[radial-gradient(circle_at_18px_18px,rgba(223,86,31,0.32)_0,rgba(223,86,31,0.32)_2px,transparent_2.5px)] [background-size:42px_42px]" />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(5,5,5,0)_0%,rgba(5,5,5,0.62)_72%,rgba(5,5,5,0.95)_100%)]" />
+      </div>
+      {enabled ? <HalftoneCanvas /> : null}
+    </>
+  );
 }

--- a/apps/web/components/landing/MobileNav.tsx
+++ b/apps/web/components/landing/MobileNav.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Menu, X } from "lucide-react";
+import { trackActivationEvent } from "@/lib/analytics/client";
+
+const NAV_LINKS = [
+  { href: "/feed", label: "Feed" },
+  { href: "/leaderboard", label: "Leaderboard" },
+  { href: "/token-rich", label: "Prometheus List" },
+] as const;
+
+export function MobileNav({ variant = "dark" }: { variant?: "dark" | "light" }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const light = variant === "light";
+  const text = light ? "text-foreground" : "text-landing-text";
+  const mobileBg = light
+    ? "border-border bg-background/95"
+    : "border-landing-border bg-landing-bg/95";
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMobileOpen(false);
+        return;
+      }
+
+      if (event.key !== "Tab" || !menuRef.current) return;
+
+      const focusable = menuRef.current.querySelectorAll<HTMLElement>(
+        'a, button, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    requestAnimationFrame(() => {
+      menuRef.current?.querySelector<HTMLElement>("a, button")?.focus();
+    });
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [mobileOpen]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`md:hidden ${text}`}
+        onClick={() => setMobileOpen((open) => !open)}
+        aria-label="Toggle menu"
+        aria-expanded={mobileOpen}
+      >
+        {mobileOpen ? <X size={24} /> : <Menu size={24} />}
+      </button>
+
+      {mobileOpen && (
+        <div
+          ref={menuRef}
+          className={`md:hidden border-t ${mobileBg} px-8 pb-8 pt-6 backdrop-blur-md`}
+          role="dialog"
+          aria-label="Mobile navigation"
+        >
+          <div className="flex flex-col gap-6 font-[family-name:var(--font-mono)] text-sm uppercase">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={text}
+                onClick={() => setMobileOpen(false)}
+              >
+                {link.label}
+              </Link>
+            ))}
+            <Link
+              href="/signup"
+              className="text-accent"
+              onClick={() => {
+                trackActivationEvent("landing_primary_cta_clicked", {
+                  surface: "landing",
+                  cta_location: "nav_mobile",
+                  destination: "/signup",
+                  activation_state: "anonymous",
+                  is_authenticated: false,
+                });
+                setMobileOpen(false);
+              }}
+            >
+              Get Started
+            </Link>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/landing/Navbar.tsx
+++ b/apps/web/components/landing/Navbar.tsx
@@ -1,82 +1,12 @@
-"use client";
-
-import { useState, useEffect, useRef, useSyncExternalStore } from "react";
 import Link from "next/link";
-import { Menu, X } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
 import { BoltIcon } from "@/components/landing/icons";
-
-function subscribeToAuthHrefChange() {
-  return () => {};
-}
-
-function getAuthHrefSnapshot() {
-  try {
-    return localStorage.getItem("straude_returning") ? "/login" : "/signup";
-  } catch {
-    return "/signup";
-  }
-}
+import { SignupCtaLink } from "@/components/landing/LandingActivationActions";
+import { MobileNav } from "@/components/landing/MobileNav";
 
 export function Navbar({ variant = "dark" }: { variant?: "dark" | "light" }) {
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const authHref = useSyncExternalStore(
-    subscribeToAuthHrefChange,
-    getAuthHrefSnapshot,
-    () => "/signup",
-  );
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  // Focus trap, Escape handler, and body scroll lock when mobile menu is open
-  useEffect(() => {
-    if (!mobileOpen) return;
-
-    // Lock body scroll
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        setMobileOpen(false);
-        return;
-      }
-      // Focus trap
-      if (e.key === "Tab" && menuRef.current) {
-        const focusable = menuRef.current.querySelectorAll<HTMLElement>(
-          'a, button, [tabindex]:not([tabindex="-1"])'
-        );
-        if (focusable.length === 0) return;
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    // Focus first link on open
-    requestAnimationFrame(() => {
-      const first = menuRef.current?.querySelector<HTMLElement>("a, button");
-      first?.focus();
-    });
-
-    return () => {
-      document.body.style.overflow = prev;
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [mobileOpen]);
-
   const light = variant === "light";
   const text = light ? "text-foreground" : "text-landing-text";
   const hoverCta = light ? "hover:text-foreground" : "hover:text-landing-text";
-  const mobileBg = light
-    ? "border-border bg-background/95"
-    : "border-landing-border bg-landing-bg/95";
 
   return (
     <nav
@@ -112,70 +42,16 @@ export function Navbar({ variant = "dark" }: { variant?: "dark" | "light" }) {
           >
             Prometheus List
           </Link>
-          <Link
-            href={authHref}
+          <SignupCtaLink
+            ctaLocation="nav_desktop"
             className={`text-accent ${hoverCta} transition-colors`}
           >
             Get Started
-          </Link>
+          </SignupCtaLink>
         </div>
 
-        {/* Mobile hamburger */}
-        <button
-          className={`md:hidden ${text}`}
-          onClick={() => setMobileOpen(!mobileOpen)}
-          aria-label="Toggle menu"
-        >
-          {mobileOpen ? <X size={24} /> : <Menu size={24} />}
-        </button>
+        <MobileNav variant={variant} />
       </div>
-
-      {/* Mobile menu */}
-      <AnimatePresence>
-        {mobileOpen && (
-          <motion.div
-            ref={menuRef}
-            className={`md:hidden border-t ${mobileBg} backdrop-blur-md px-8 pb-8 pt-6`}
-            initial={{ opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
-            role="dialog"
-            aria-label="Mobile navigation"
-          >
-            <div className="flex flex-col gap-6 font-[family-name:var(--font-mono)] text-sm uppercase">
-              <Link
-                href="/feed"
-                className={text}
-                onClick={() => setMobileOpen(false)}
-              >
-                Feed
-              </Link>
-              <Link
-                href="/leaderboard"
-                className={text}
-                onClick={() => setMobileOpen(false)}
-              >
-                Leaderboard
-              </Link>
-              <Link
-                href="/token-rich"
-                className={text}
-                onClick={() => setMobileOpen(false)}
-              >
-                Prometheus List
-              </Link>
-              <Link
-                href={authHref}
-                className="text-accent"
-                onClick={() => setMobileOpen(false)}
-              >
-                Get Started
-              </Link>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
     </nav>
   );
 }

--- a/apps/web/components/landing/ProductHuntBadge.tsx
+++ b/apps/web/components/landing/ProductHuntBadge.tsx
@@ -1,10 +1,5 @@
 const PRODUCT_HUNT_URL =
   "https://www.producthunt.com/products/straude/launches/straude?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-straude";
-const BADGE_SRC =
-  "https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1114059&theme=dark&t=1777407227004";
-
-const WIDTH = 188;
-const HEIGHT = 41;
 
 export function ProductHuntBadge() {
   return (
@@ -12,16 +7,10 @@ export function ProductHuntBadge() {
       href={PRODUCT_HUNT_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-block transition-transform active:scale-[0.98]"
+      className="inline-flex items-center gap-2 border border-landing-border bg-landing-panel px-3 py-2 font-[family-name:var(--font-mono)] text-xs uppercase tracking-wider text-landing-muted transition-[border-color,color,transform] hover:border-accent/50 hover:text-landing-text active:scale-[0.98]"
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={BADGE_SRC}
-        alt="Straude - Strava for Claude Code, the global tokenmaxxing Leaderboard | Product Hunt"
-        width={WIDTH}
-        height={HEIGHT}
-        style={{ width: WIDTH, height: HEIGHT }}
-      />
+      <span className="text-accent">Featured</span>
+      <span>on Product Hunt</span>
     </a>
   );
 }

--- a/apps/web/components/landing/WallOfLove.tsx
+++ b/apps/web/components/landing/WallOfLove.tsx
@@ -1,8 +1,5 @@
-"use client";
-
 import Image from "next/image";
 import type { WallOfLovePost } from "@/types";
-import { motion, type Variants } from "motion/react";
 
 function XIcon({ className }: { className?: string }) {
   return (
@@ -17,26 +14,10 @@ function XIcon({ className }: { className?: string }) {
   );
 }
 
-const wallCardVariants: Variants = {
-  hidden: { opacity: 0, y: 28, scale: 0.97 },
-  visible: (i: number) => ({
-    opacity: 1,
-    y: 0,
-    scale: 1,
-    transition: {
-      delay: i * 0.04,
-      duration: 0.55,
-      ease: [0.25, 0.46, 0.45, 0.94],
-    },
-  }),
-};
-
 function WallOfLoveCard({
   post,
-  index,
 }: {
   post: WallOfLovePost;
-  index: number;
 }) {
   const initials = post.author_name
     .split(" ")
@@ -44,16 +25,11 @@ function WallOfLoveCard({
     .join("");
 
   return (
-    <motion.a
+    <a
       href={post.url}
       target="_blank"
       rel="noopener noreferrer"
       className="mb-5 block break-inside-avoid border border-landing-border bg-landing-panel p-6 transition-[border-color] duration-200 hover:border-accent/40"
-      custom={index}
-      variants={wallCardVariants}
-      initial="hidden"
-      whileInView="visible"
-      viewport={{ once: true, amount: 0.15 }}
     >
       {/* Header: avatar + name + X icon */}
       <div className="flex items-start gap-3">
@@ -92,7 +68,7 @@ function WallOfLoveCard({
       <p className="mt-4 text-xs text-landing-dim font-[family-name:var(--font-mono)]">
         {post.date}
       </p>
-    </motion.a>
+    </a>
   );
 }
 
@@ -102,22 +78,16 @@ export function WallOfLove({ posts }: { posts: WallOfLovePost[] }) {
   return (
     <section className="border-t border-landing-border py-24 md:py-32">
       <div className="mx-auto max-w-[1280px] px-8">
-        <motion.div
-          className="flex flex-col items-center text-center mb-14"
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.5 }}
-          transition={{ duration: 0.5, ease: "easeOut" }}
-        >
+        <div className="mb-14 flex flex-col items-center text-center">
           <h2 className="text-[clamp(2rem,4vw,3.5rem)] font-medium tracking-[-0.03em] text-balance text-landing-text">
             Everybody is <span className="text-accent">Claudemaxxing</span>.
             Are you?
           </h2>
-        </motion.div>
+        </div>
 
         <div className="columns-1 sm:columns-2 lg:columns-3 gap-5">
-          {posts.map((post, i) => (
-            <WallOfLoveCard key={post.url} post={post} index={i} />
+          {posts.map((post) => (
+            <WallOfLoveCard key={post.url} post={post} />
           ))}
         </div>
       </div>

--- a/apps/web/components/landing/constants.ts
+++ b/apps/web/components/landing/constants.ts
@@ -1,0 +1,1 @@
+export const LANDING_SYNC_COMMAND = "npx straude@latest";

--- a/apps/web/e2e/golden-path/landing-to-signup.spec.ts
+++ b/apps/web/e2e/golden-path/landing-to-signup.spec.ts
@@ -45,9 +45,28 @@ test.describe("Landing → Signup funnel", () => {
     await page.goto("/");
 
     // The hero's "Start Your Streak" link specifically
-    const startCTA = page.locator('a:has-text("Start Your Streak")');
+    const startCTA = page
+      .locator("header")
+      .getByRole("link", { name: "Start Your Streak" });
     await expect(startCTA).toBeVisible();
     await expect(startCTA).toHaveAttribute("href", "/signup");
+  });
+
+  test("uses one canonical sync command across the landing page", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByText("npx straude@latest").first()).toBeVisible();
+    await expect(page.getByText("npx straude push --days 7")).toHaveCount(0);
+  });
+
+  test("final CTA offers signup and command copy actions", async ({ page }) => {
+    await page.goto("/");
+
+    const finalSection = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Ready to run?" }),
+    });
+    await expect(finalSection.getByRole("link", { name: "Start Your Streak" })).toHaveAttribute("href", "/signup");
+    await expect(finalSection.getByRole("button", { name: /npx straude@latest/ })).toBeVisible();
   });
 
   test("navbar Get Started links to signup or login", async ({ page }) => {

--- a/apps/web/lib/open-stats.ts
+++ b/apps/web/lib/open-stats.ts
@@ -411,53 +411,57 @@ async function persistOpenStatsSnapshot(db: OpenStatsDb, stats: OpenStats) {
   throwIfSupabaseError("open stats snapshot write failed", result.error);
 }
 
+function createPlaceholderOpenStats(): OpenStats {
+  const now = new Date().toISOString();
+  return {
+    trackedUsers: 0,
+    totalUsers: 0,
+    totalSpend: 0,
+    avgWeeklySpend: 0,
+    totalTokens: 0,
+    totalSessions: 0,
+    avgStreak: 0,
+    totalStreaks: 0,
+    concentration: [],
+    cumulativePct: {},
+    models: [],
+    fetchedAt: now,
+    snapshotDate: snapshotDateFromIso(now),
+    source: "snapshot",
+  };
+}
+
+export async function refreshOpenStatsSnapshot(
+  db: OpenStatsDb = getServiceClient() as unknown as OpenStatsDb,
+): Promise<OpenStats> {
+  const liveStats = await fetchLiveOpenStats(db);
+
+  try {
+    await persistOpenStatsSnapshot(db, liveStats);
+  } catch (error) {
+    // TODO(observability): forward to PostHog server-side capture once a
+    // helper exists (context: "open-stats:snapshot-write"). For now, log
+    // so prod failures are visible in server logs.
+    logOpenStatsError("open stats snapshot write failed:", error);
+  }
+
+  return liveStats;
+}
+
 export async function getOpenStatsForPage(
   db: OpenStatsDb = getServiceClient() as unknown as OpenStatsDb,
 ): Promise<OpenStats> {
   try {
-    const liveStats = await fetchLiveOpenStats(db);
-
-    try {
-      await persistOpenStatsSnapshot(db, liveStats);
-    } catch (error) {
-      // TODO(observability): forward to PostHog server-side capture once a
-      // helper exists (context: "open-stats:snapshot-write"). For now, log
-      // so prod failures are visible in server logs.
-      logOpenStatsError("open stats snapshot write failed:", error);
-    }
-
-    return liveStats;
-  } catch (liveError) {
-    try {
-      const snapshot = await readLatestOpenStatsSnapshot(db);
-      if (snapshot) return snapshot;
-    } catch (snapshotError) {
-      // TODO(observability): forward to PostHog server-side capture once a
-      // helper exists (context: "open-stats:snapshot-fallback").
-      logOpenStatsError("open stats snapshot fallback failed:", snapshotError);
-    }
-
-    // Both live and snapshot failed (e.g. Supabase unreachable in CI).
-    // Return an empty placeholder so the build doesn't crash.
+    const snapshot = await readLatestOpenStatsSnapshot(db);
+    if (snapshot) return snapshot;
+  } catch (snapshotError) {
     // TODO(observability): forward to PostHog server-side capture once a
-    // helper exists (context: "open-stats:all-sources-failed").
-    logOpenStatsError("open stats: all sources failed, returning placeholder", liveError);
-    const now = new Date().toISOString();
-    return {
-      trackedUsers: 0,
-      totalUsers: 0,
-      totalSpend: 0,
-      avgWeeklySpend: 0,
-      totalTokens: 0,
-      totalSessions: 0,
-      avgStreak: 0,
-      totalStreaks: 0,
-      concentration: [],
-      cumulativePct: {},
-      models: [],
-      fetchedAt: now,
-      snapshotDate: snapshotDateFromIso(now),
-      source: "snapshot",
-    };
+    // helper exists (context: "open-stats:snapshot-read").
+    logOpenStatsError("open stats snapshot read failed:", snapshotError);
   }
+
+  // Public pages must not run the 50k-row live aggregation path during render.
+  // Return a coherent placeholder until the scheduled/admin refresh writes a
+  // new durable snapshot.
+  return createPlaceholderOpenStats();
 }


### PR DESCRIPTION
## Summary
- moves landing CTA tracking into small client islands so hero/nav/wall sections can render without broad client-side motion code
- standardizes landing copy and command surfaces on npx straude@latest while keeping Prometheus List
- delays the halftone canvas until idle and respects reduced-motion/data-saver preferences
- replaces the remote Product Hunt badge asset with local styled text
- serves /open from the latest persisted snapshot instead of live aggregation during page render

## Verification
- bun --cwd apps/web test -- __tests__/lib/open-stats.test.ts __tests__/flows/activation-contract.test.ts
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun --cwd apps/web test:e2e -- e2e/golden-path/landing-to-signup.spec.ts