### PR TITLE
Defer authenticated shell work

### DIFF
--- a/apps/web/__tests__/components/CommandPalette.test.tsx
+++ b/apps/web/__tests__/components/CommandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
@@ -40,6 +40,7 @@ vi.mock("kbar", () => ({
   }) => <div className={className}>{children}</div>,
   KBarSearch: ({ className }: { className?: string }) => <input className={className} />,
   KBarResults: () => null,
+  useKBar: () => ({ query: { toggle: vi.fn() } }),
   useMatches: () => ({ results: [] }),
 }));
 
@@ -92,9 +93,13 @@ describe("CommandPalette", () => {
       </ThemeProvider>,
     );
 
-    expect(capturedActions.map((action) => action.id)).toEqual(
-      expect.arrayContaining(["theme-light", "theme-dark", "theme-system"]),
-    );
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    await waitFor(() => {
+      expect(capturedActions.map((action) => action.id)).toEqual(
+        expect.arrayContaining(["theme-light", "theme-dark", "theme-system"]),
+      );
+    });
 
     const darkAction = capturedActions.find((action) => action.id === "theme-dark");
     act(() => {

--- a/apps/web/__tests__/components/SubmitPromptWidget.test.tsx
+++ b/apps/web/__tests__/components/SubmitPromptWidget.test.tsx
@@ -7,6 +7,11 @@ describe("SubmitPromptWidget", () => {
     vi.restoreAllMocks();
   });
 
+  async function openPromptModal() {
+    fireEvent.click(screen.getByRole("button", { name: /submit a prompt/i }));
+    return screen.findByRole("dialog");
+  }
+
   it("opens the modal and submits a prompt", async () => {
     const fetchMock = vi.spyOn(global, "fetch" as any).mockResolvedValue({
       ok: true,
@@ -15,8 +20,7 @@ describe("SubmitPromptWidget", () => {
 
     render(<SubmitPromptWidget username="jane" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /submit a prompt/i }));
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(await openPromptModal()).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Prompt"), {
       target: { value: "Please add a compact mode for activity cards in the feed." },
@@ -52,7 +56,7 @@ describe("SubmitPromptWidget", () => {
 
     render(<SubmitPromptWidget username="jane" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /submit a prompt/i }));
+    await openPromptModal();
 
     fireEvent.change(screen.getByLabelText("Prompt"), {
       target: { value: "Please add markdown shortcuts in comments." },
@@ -74,7 +78,7 @@ describe("SubmitPromptWidget", () => {
 
     render(<SubmitPromptWidget username="jane" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /submit a prompt/i }));
+    await openPromptModal();
     fireEvent.click(screen.getByRole("button", { name: /submit as anonymous/i }));
 
     fireEvent.change(screen.getByLabelText("Prompt"), {
@@ -96,10 +100,10 @@ describe("SubmitPromptWidget", () => {
     });
   });
 
-  it("shows the submit keyboard shortcut hint", () => {
+  it("shows the submit keyboard shortcut hint", async () => {
     render(<SubmitPromptWidget username="jane" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /submit a prompt/i }));
+    await openPromptModal();
 
     expect(
       screen.getByRole("button", { name: /submit prompt ⌘↵/i }),
@@ -131,7 +135,7 @@ describe("SubmitPromptWidget", () => {
 
     render(<SubmitPromptWidget username="jane" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /submit a prompt/i }));
+    await openPromptModal();
     fireEvent.click(screen.getByRole("button", { name: /view community prompts/i }));
 
     await waitFor(() => {

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -4,14 +4,16 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { getAuthUser } from "@/lib/supabase/auth";
 import { Sidebar } from "@/components/app/shared/Sidebar";
-import { RightSidebar } from "@/components/app/shared/RightSidebar";
+import { LazyRightSidebar } from "@/components/app/shared/RightSidebar";
 import { InviteButton } from "@/components/app/profile/InviteButton";
 import { ResponsiveShellFrame } from "@/components/app/shared/ResponsiveShellFrame";
 import { GuestHeader, GuestMobileNav } from "@/components/app/shared/GuestHeader";
 import { CommandPalette } from "@/components/app/shared/CommandPalette";
 import { Avatar } from "@/components/ui/Avatar";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { AppProviders } from "@/components/providers/AppProviders";
 import { firstRelation } from "@/lib/utils/first-relation";
+import { loadUsageTotals } from "@/lib/data/usage-totals";
 import type { DailyUsage } from "@/types";
 
 type ShellProfile = {
@@ -31,65 +33,7 @@ type LatestPostRow = {
   daily_usage: Array<Pick<DailyUsage, "date">> | null;
 };
 
-type UsageFallbackRow = Pick<DailyUsage, "cost_usd" | "output_tokens">;
-type UsageTotalsRpcRow = {
-  total_cost: number | string | null;
-  total_tokens: number | string | null;
-};
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
-
-async function loadUsageTotals(
-  supabase: SupabaseServerClient,
-  userId: string,
-): Promise<{ totalTokens: number; totalCost: number }> {
-  const usageTotalsRes = await supabase
-    .rpc("get_user_usage_totals", { p_user_id: userId })
-    .single();
-
-  const loadFallbackUsageTotals = async (): Promise<{ totalTokens: number; totalCost: number }> => {
-    const { data: fallbackRows, error: fallbackError } = await supabase
-      .from("daily_usage")
-      .select("cost_usd, output_tokens")
-      .eq("user_id", userId);
-
-    if (fallbackError) {
-      throw new Error(`Unable to load usage totals from daily_usage fallback (${fallbackError.message})`);
-    }
-
-    const rows = (fallbackRows ?? []) as UsageFallbackRow[];
-    return {
-      totalTokens: rows.reduce((sum, row) => sum + Number(row.output_tokens), 0),
-      totalCost: rows.reduce((sum, row) => sum + Number(row.cost_usd), 0),
-    };
-  };
-
-  if (usageTotalsRes.error) {
-    console.error("get_user_usage_totals RPC failed; using direct daily_usage fallback", {
-      userId,
-      code: usageTotalsRes.error.code,
-      message: usageTotalsRes.error.message,
-    });
-
-    return loadFallbackUsageTotals();
-  }
-
-  const usageTotals = usageTotalsRes.data as UsageTotalsRpcRow | null;
-  const rpcTokens = usageTotals?.total_tokens;
-
-  if (rpcTokens === null || rpcTokens === undefined) {
-    console.error("get_user_usage_totals returned no total_tokens; using direct daily_usage fallback", {
-      userId,
-      rpcKeys: usageTotals ? Object.keys(usageTotals) : [],
-    });
-
-    return loadFallbackUsageTotals();
-  }
-
-  return {
-    totalTokens: Number(rpcTokens),
-    totalCost: Number(usageTotals?.total_cost ?? 0),
-  };
-}
 
 function formatLatestPosts(rows: LatestPostRow[]) {
   return rows
@@ -179,23 +123,6 @@ function SidebarFallback({ profile }: { profile: ShellProfile | null }) {
   );
 }
 
-function RightSidebarFallback() {
-  return (
-    <div className="flex flex-col">
-      {[0, 1, 2].map((section) => (
-        <div key={section} className="border-b border-border p-6">
-          <Skeleton className="mb-4 h-3 w-28" />
-          <div className="space-y-3">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-5/6" />
-            <Skeleton className="h-4 w-3/4" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 async function DeferredSidebar({
   userId,
   profile,
@@ -252,22 +179,6 @@ async function DeferredSidebar({
   );
 }
 
-async function DeferredRightSidebar({
-  userId,
-}: {
-  userId: string;
-}) {
-  const supabase = await createClient();
-  const usageTotals = await loadUsageTotals(supabase, userId);
-
-  return (
-    <RightSidebar
-      userId={userId}
-      totalOutputTokens={usageTotals.totalTokens}
-    />
-  );
-}
-
 async function PhotoNudge({
   userId,
   onboardingIncomplete,
@@ -311,17 +222,19 @@ export default async function AppLayout({
     // This check runs server-side as a safety net alongside proxy.ts
     // Public pages render with a guest layout below
     return (
-      <div className="fixed inset-0 flex flex-col overflow-hidden">
-        <GuestHeader />
-          <div className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 overflow-hidden border-x border-border">
-            <main id="main-content" className="scrollbar-none min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
-              <div className="pb-[var(--mobile-nav-height)] sm:pb-0">
-                {children}
-              </div>
-            </main>
-          </div>
-          <GuestMobileNav />
-      </div>
+      <AppProviders>
+        <div className="fixed inset-0 flex flex-col overflow-hidden">
+          <GuestHeader />
+            <div className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 overflow-hidden border-x border-border">
+              <main id="main-content" className="scrollbar-none min-w-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
+                <div className="pb-[var(--mobile-nav-height)] sm:pb-0">
+                  {children}
+                </div>
+              </main>
+            </div>
+            <GuestMobileNav />
+        </div>
+      </AppProviders>
     );
   }
 
@@ -341,39 +254,38 @@ export default async function AppLayout({
     </Suspense>
   );
 
-  const rightPanel = (
-    <Suspense fallback={<RightSidebarFallback />}>
-      <DeferredRightSidebar userId={user.id} />
-    </Suspense>
-  );
+  const rightPanel = <LazyRightSidebar />;
 
   return (
-    <CommandPalette username={profile?.username ?? null}>
-      <div className="fixed inset-0 flex flex-col overflow-hidden">
-        {onboardingIncomplete && (
-          <div className="flex items-center justify-center gap-2 border-b border-border bg-accent/5 px-4 py-2 text-sm">
-            <span className="text-muted">Finish setting up your profile</span>
-            <Link href="/onboarding" className="font-medium text-accent hover:underline">
-              Complete onboarding
-            </Link>
-          </div>
-        )}
-        <Suspense fallback={null}>
-          <PhotoNudge
-            userId={user.id}
-            onboardingIncomplete={onboardingIncomplete}
-          />
-        </Suspense>
+    <AppProviders>
+      <CommandPalette username={profile?.username ?? null}>
+        <div className="fixed inset-0 flex flex-col overflow-hidden">
+          {onboardingIncomplete && (
+            <div className="flex items-center justify-center gap-2 border-b border-border bg-accent/5 px-4 py-2 text-sm">
+              <span className="text-muted">Finish setting up your profile</span>
+              <Link href="/onboarding" className="font-medium text-accent hover:underline">
+                Complete onboarding
+              </Link>
+            </div>
+          )}
+          <Suspense fallback={null}>
+            <PhotoNudge
+              userId={user.id}
+              onboardingIncomplete={onboardingIncomplete}
+            />
+          </Suspense>
 
-        <ResponsiveShellFrame
-          username={profile?.username ?? null}
-          avatarUrl={profile?.avatar_url ?? null}
-          leftPanel={leftPanel}
-          rightPanel={rightPanel}
-        >
-          {children}
-        </ResponsiveShellFrame>
-      </div>
-    </CommandPalette>
+          <ResponsiveShellFrame
+            username={profile?.username ?? null}
+            avatarUrl={profile?.avatar_url ?? null}
+            leftPanel={leftPanel}
+            rightPanel={rightPanel}
+            showPromptWidget={!onboardingIncomplete}
+          >
+            {children}
+          </ResponsiveShellFrame>
+        </div>
+      </CommandPalette>
+    </AppProviders>
   );
 }

--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { PublicAnalytics } from "@/components/providers/PublicAnalytics";
 
 export const metadata: Metadata = {
   title: "Sign in to Straude",
@@ -13,8 +14,11 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <main id="main-content" className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
-      <div className="w-full max-w-md">{children}</div>
-    </main>
+    <>
+      <main id="main-content" className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+        <div className="w-full max-w-md">{children}</div>
+      </main>
+      <PublicAnalytics />
+    </>
   );
 }

--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { CookieConsentModal } from "@/components/landing/CookieConsentModal";
+import { PublicAnalytics } from "@/components/providers/PublicAnalytics";
 
 export const metadata: Metadata = {
   title: { absolute: "Straude — Strava for Claude Code" },
@@ -15,6 +16,7 @@ export default function LandingLayout({
   return (
     <>
       {children}
+      <PublicAnalytics />
       <CookieConsentModal />
     </>
   );

--- a/apps/web/app/(onboarding)/layout.tsx
+++ b/apps/web/app/(onboarding)/layout.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { redirect } from "next/navigation";
+import { AppProviders } from "@/components/providers/AppProviders";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -35,8 +36,10 @@ export default async function OnboardingLayout({
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
-      <div className="w-full max-w-md">{children}</div>
-    </div>
+    <AppProviders>
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="w-full max-w-md">{children}</div>
+      </div>
+    </AppProviders>
   );
 }

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { isAdmin } from "@/lib/admin";
 import { AdminShell } from "./components/AdminShell";
+import { AppProviders } from "@/components/providers/AppProviders";
 import type { Metadata } from "next";
 import "./admin.css";
 
@@ -21,5 +22,9 @@ export default async function AdminLayout({
     redirect("/feed");
   }
 
-  return <AdminShell>{children}</AdminShell>;
+  return (
+    <AppProviders>
+      <AdminShell>{children}</AdminShell>
+    </AppProviders>
+  );
 }

--- a/apps/web/app/api/app/right-sidebar/route.ts
+++ b/apps/web/app/api/app/right-sidebar/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service";
+import { loadUsageTotals } from "@/lib/data/usage-totals";
+import type {
+  RightSidebarSuggestedUser,
+  RightSidebarTopUser,
+} from "@/lib/query/right-sidebar";
+
+type ActiveUserRelation = {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+  bio: string | null;
+  is_public: boolean;
+};
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const service = getServiceClient();
+
+  const [{ data: topUsers }, { data: following }, usageTotals] = await Promise.all([
+    supabase
+      .from("leaderboard_weekly")
+      .select("user_id, username, avatar_url, total_cost")
+      .order("total_cost", { ascending: false })
+      .limit(5),
+    supabase
+      .from("follows")
+      .select("following_id")
+      .eq("follower_id", user.id),
+    loadUsageTotals(supabase, user.id),
+  ]);
+
+  const followingIds = following?.map((f) => f.following_id) ?? [];
+  const excludeIds = [user.id, ...followingIds];
+  const excludeFilter = `(${excludeIds.join(",")})`;
+
+  const [{ data: pinnedUsers }, { data: recentlyActive }, { data: newSignups }] =
+    await Promise.all([
+      service
+        .from("users")
+        .select("id, username, avatar_url, bio")
+        .eq("is_pinned_suggestion", true)
+        .not("id", "in", excludeFilter),
+      service
+        .from("daily_usage")
+        .select("user_id, users!inner(id, username, avatar_url, bio, is_public)")
+        .not("users.username", "is", null)
+        .not("user_id", "in", excludeFilter)
+        .order("date", { ascending: false })
+        .limit(20),
+      service
+        .from("users")
+        .select("id, username, avatar_url, bio")
+        .eq("is_public", true)
+        .not("username", "is", null)
+        .not("id", "in", excludeFilter)
+        .order("created_at", { ascending: false })
+        .limit(10),
+    ]);
+
+  const pinnedIds = new Set((pinnedUsers ?? []).map((u) => u.id));
+  const seenIds = new Set<string>();
+  const activeUsers: RightSidebarSuggestedUser[] = [];
+
+  for (const row of recentlyActive ?? []) {
+    const candidate = row.users as unknown as ActiveUserRelation;
+    if (!seenIds.has(candidate.id) && !pinnedIds.has(candidate.id) && candidate.is_public) {
+      seenIds.add(candidate.id);
+      activeUsers.push({
+        id: candidate.id,
+        username: candidate.username,
+        avatar_url: candidate.avatar_url,
+        bio: candidate.bio,
+      });
+    }
+  }
+
+  const merged: RightSidebarSuggestedUser[] = [];
+  for (const candidate of activeUsers) {
+    if (!merged.some((item) => item.id === candidate.id)) merged.push(candidate);
+  }
+
+  for (const candidate of newSignups ?? []) {
+    if (!candidate.username) continue;
+    if (pinnedIds.has(candidate.id) || merged.some((item) => item.id === candidate.id)) continue;
+    merged.push({
+      id: candidate.id,
+      username: candidate.username,
+      avatar_url: candidate.avatar_url,
+      bio: candidate.bio,
+    });
+  }
+
+  const pinnedList: RightSidebarSuggestedUser[] = (pinnedUsers ?? [])
+    .filter((candidate) => candidate.username)
+    .map((candidate) => ({
+      id: candidate.id,
+      username: candidate.username as string,
+      avatar_url: candidate.avatar_url,
+      bio: candidate.bio,
+    }));
+  const organicLimit = Math.max(0, 5 - pinnedList.length);
+  const suggested = [...merged.slice(0, organicLimit), ...pinnedList].slice(0, 5);
+
+  return NextResponse.json({
+    suggested,
+    topUsers: (topUsers ?? []) as RightSidebarTopUser[],
+    totalOutputTokens: usageTotals.totalTokens,
+  });
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,10 +2,6 @@ import type { Metadata, Viewport } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { Agentation } from "agentation";
 import Script from "next/script";
-import { ConsentAwareAnalytics } from "@/components/providers/ConsentAwareAnalytics";
-import { PostHogClientProvider } from "@/components/providers/PostHogProvider";
-import { QueryProvider } from "@/components/providers/QueryProvider";
-import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { getThemeBootstrapScript } from "@/lib/theme";
 import "./globals.css";
 
@@ -126,12 +122,7 @@ export default function RootLayout({
         >
           Skip to content
         </a>
-        <PostHogClientProvider>
-          <QueryProvider>
-            <ThemeProvider>{children}</ThemeProvider>
-          </QueryProvider>
-        </PostHogClientProvider>
-        <ConsentAwareAnalytics />
+        {children}
         {process.env.NODE_ENV === "development" && <Agentation />}
       </body>
     </html>

--- a/apps/web/components/app/prompts/SubmitPromptModal.tsx
+++ b/apps/web/components/app/prompts/SubmitPromptModal.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Textarea } from "@/components/ui/Textarea";
+import { useFocusTrap } from "@/components/app/shared/useFocusTrap";
+import { timeAgo } from "@/lib/utils/format";
+
+const MAX_PROMPT_LENGTH = 2_000;
+type ModalView = "submit" | "community";
+
+interface CommunityPromptRow {
+  id: string;
+  prompt: string;
+  is_anonymous: boolean;
+  created_at: string;
+  user?: { username?: string | null } | null;
+}
+
+interface SubmitPromptModalProps {
+  username?: string | null;
+  onClose: () => void;
+  onSubmitted: (message: string) => void;
+}
+
+export function SubmitPromptModal({
+  username,
+  onClose,
+  onSubmitted,
+}: SubmitPromptModalProps) {
+  const [view, setView] = useState<ModalView>("submit");
+  const [prompt, setPrompt] = useState("");
+  const [anonymous, setAnonymous] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [communityPrompts, setCommunityPrompts] = useState<CommunityPromptRow[]>([]);
+  const [communityLoading, setCommunityLoading] = useState(false);
+  const [communityError, setCommunityError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (view !== "submit") return;
+    const id = window.setTimeout(() => textareaRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [view]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  useFocusTrap(dialogRef, true);
+
+  async function loadCommunityPrompts() {
+    if (communityLoading) return;
+    setCommunityLoading(true);
+    setCommunityError(null);
+    try {
+      const res = await fetch("/api/prompts?limit=20&offset=0");
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setCommunityError(body.error ?? "Failed to load community prompts");
+        return;
+      }
+      setCommunityPrompts(Array.isArray(body.prompts) ? body.prompts : []);
+    } catch {
+      setCommunityError("Failed to load community prompts");
+    } finally {
+      setCommunityLoading(false);
+    }
+  }
+
+  async function openCommunityView() {
+    setView("community");
+    if (communityPrompts.length === 0) {
+      await loadCommunityPrompts();
+    }
+  }
+
+  async function handleSubmit() {
+    const trimmed = prompt.trim();
+    if (!trimmed) {
+      setError("Prompt is required");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/prompts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt: trimmed,
+          anonymous,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body.error ?? "Failed to submit prompt");
+        return;
+      }
+      onSubmitted("Prompt submitted.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="submit-prompt-title"
+        className="w-full max-w-3xl rounded-[8px] border border-border bg-background shadow-xl"
+      >
+        <div className="flex items-start justify-between border-b border-border px-5 py-4 sm:px-6 sm:py-5">
+          <div>
+            <h2 id="submit-prompt-title" className="text-2xl font-semibold text-balance">
+              {view === "submit" ? "Submit a prompt" : "Community prompts"}
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm text-muted">
+              {view === "submit"
+                ? "Prompt a coding agent to build what you want to see in Straude. If we like your prompt, we'll run it and merge the result."
+                : "Browse what people want us to build next."}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-[4px] border border-border p-2 text-muted hover:text-foreground"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {view === "submit" ? (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleSubmit();
+            }}
+            className="space-y-5 px-5 py-5 sm:px-6 sm:py-6"
+          >
+            <div>
+              <label htmlFor="prompt-input" className="mb-2 block text-base font-semibold">
+                Prompt
+              </label>
+              <Textarea
+                id="prompt-input"
+                ref={textareaRef}
+                rows={7}
+                maxLength={MAX_PROMPT_LENGTH}
+                placeholder={"What should we build or improve?\n\nIdeas to get started:\n- Feature request: \"Add keyboard shortcuts for editing posts\"\n- Bug fix: \"Comments flash as anonymous after posting\"\n- UI nitpick: \"Tighten spacing in the feed cards\"\n- Growth idea: \"Add a referral badge to help more people discover Straude\""}
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                    e.preventDefault();
+                    void handleSubmit();
+                  }
+                }}
+                error={!!error}
+              />
+              <div className="mt-2 flex items-center justify-between text-xs text-muted">
+                <span>Be specific about behavior, UX, and edge cases.</span>
+                <span className="tabular-nums">
+                  {prompt.length}/{MAX_PROMPT_LENGTH}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-[4px] border border-border bg-subtle px-3 py-2">
+              <p className="text-sm text-muted">
+                {anonymous
+                  ? "Submitting as Anonymous"
+                  : username
+                    ? `Submitting as @${username}`
+                    : "Submitting with your account"}
+              </p>
+              <button
+                type="button"
+                onClick={() => setAnonymous((v) => !v)}
+                className="text-sm font-medium text-accent hover:underline"
+              >
+                {anonymous ? "Submit with username" : "Submit as anonymous"}
+              </button>
+            </div>
+
+            {error && (
+              <p role="alert" className="text-sm text-error">
+                {error}
+              </p>
+            )}
+
+            <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  void openCommunityView();
+                }}
+                className="text-left text-sm font-medium text-accent hover:underline"
+              >
+                View community prompts
+              </button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? "Submitting..." : "Submit prompt ⌘↵"}
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <div className="space-y-4 px-5 py-5 sm:px-6 sm:py-6">
+            <div className="max-h-[420px] overflow-y-auto rounded-[4px] border border-border">
+              {communityLoading ? (
+                <p className="px-4 py-8 text-center text-sm text-muted">
+                  Loading community prompts...
+                </p>
+              ) : communityError ? (
+                <p role="alert" className="px-4 py-8 text-center text-sm text-error">
+                  {communityError}
+                </p>
+              ) : communityPrompts.length === 0 ? (
+                <p className="px-4 py-8 text-center text-sm text-muted">
+                  No prompts yet.
+                </p>
+              ) : (
+                <div className="divide-y divide-border">
+                  {communityPrompts.map((row) => {
+                    const usernameValue = row.user?.username ?? null;
+                    const canLink = Boolean(usernameValue && !row.is_anonymous);
+                    return (
+                      <article key={row.id} className="px-4 py-4">
+                        <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                          {canLink ? (
+                            <Link
+                              href={`/u/${usernameValue}`}
+                              className="font-semibold text-accent hover:underline"
+                            >
+                              @{usernameValue}
+                            </Link>
+                          ) : (
+                            <span className="font-semibold text-muted">
+                              {row.is_anonymous ? "Anonymous" : "Unknown user"}
+                            </span>
+                          )}
+                          <span suppressHydrationWarning className="text-muted">
+                            {timeAgo(row.created_at)}
+                          </span>
+                        </div>
+                        <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                          {row.prompt}
+                        </p>
+                      </article>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center">
+              <button
+                type="button"
+                onClick={() => setView("submit")}
+                className="text-left text-sm font-medium text-accent hover:underline"
+              >
+                Back to submit a prompt
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/components/app/prompts/SubmitPromptWidget.tsx
+++ b/apps/web/components/app/prompts/SubmitPromptWidget.tsx
@@ -1,24 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import Link from "next/link";
-import { X, Sparkles } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/Button";
-import { Textarea } from "@/components/ui/Textarea";
-import { useFocusTrap } from "@/components/app/shared/useFocusTrap";
-import { timeAgo } from "@/lib/utils/format";
 
-const MAX_PROMPT_LENGTH = 2000;
-type ModalView = "submit" | "community";
-
-interface CommunityPromptRow {
-  id: string;
-  prompt: string;
-  is_anonymous: boolean;
-  created_at: string;
-  user?: { username?: string | null } | null;
-}
+const SubmitPromptModal = dynamic(
+  () => import("@/components/app/prompts/SubmitPromptModal").then((mod) => mod.SubmitPromptModal),
+  { ssr: false },
+);
 
 interface SubmitPromptWidgetProps {
   username?: string | null;
@@ -26,45 +16,8 @@ interface SubmitPromptWidgetProps {
 
 export function SubmitPromptWidget({ username }: SubmitPromptWidgetProps) {
   const [open, setOpen] = useState(false);
-  const [view, setView] = useState<ModalView>("submit");
-  const [prompt, setPrompt] = useState("");
-  const [anonymous, setAnonymous] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [flash, setFlash] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [communityPrompts, setCommunityPrompts] = useState<CommunityPromptRow[]>([]);
-  const [communityLoading, setCommunityLoading] = useState(false);
-  const [communityError, setCommunityError] = useState<string | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const original = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = original;
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open || view !== "submit") return;
-    const id = window.setTimeout(() => textareaRef.current?.focus(), 0);
-    return () => window.clearTimeout(id);
-  }, [open, view]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setOpen(false);
-      }
-    }
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [open]);
 
   useEffect(() => {
     if (!open) {
@@ -72,73 +25,11 @@ export function SubmitPromptWidget({ username }: SubmitPromptWidgetProps) {
     }
   }, [open]);
 
-  useFocusTrap(dialogRef, open);
-
   useEffect(() => {
     if (!flash) return;
-    const id = window.setTimeout(() => setFlash(null), 4500);
+    const id = window.setTimeout(() => setFlash(null), 4_500);
     return () => window.clearTimeout(id);
   }, [flash]);
-
-  async function loadCommunityPrompts() {
-    if (communityLoading) return;
-    setCommunityLoading(true);
-    setCommunityError(null);
-    try {
-      const res = await fetch("/api/prompts?limit=20&offset=0");
-      const body = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        setCommunityError(body.error ?? "Failed to load community prompts");
-        return;
-      }
-      setCommunityPrompts(Array.isArray(body.prompts) ? body.prompts : []);
-    } catch {
-      setCommunityError("Failed to load community prompts");
-    } finally {
-      setCommunityLoading(false);
-    }
-  }
-
-  async function openCommunityView() {
-    setView("community");
-    if (communityPrompts.length === 0) {
-      await loadCommunityPrompts();
-    }
-  }
-
-  async function handleSubmit() {
-    const trimmed = prompt.trim();
-    if (!trimmed) {
-      setError("Prompt is required");
-      return;
-    }
-
-    setSubmitting(true);
-    setError(null);
-
-    try {
-      const res = await fetch("/api/prompts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          prompt: trimmed,
-          anonymous,
-        }),
-      });
-      const body = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        setError(body.error ?? "Failed to submit prompt");
-        return;
-      }
-      setPrompt("");
-      setAnonymous(false);
-      setView("submit");
-      setOpen(false);
-      setFlash("Prompt submitted.");
-    } finally {
-      setSubmitting(false);
-    }
-  }
 
   return (
     <>
@@ -154,190 +45,22 @@ export function SubmitPromptWidget({ username }: SubmitPromptWidgetProps) {
         size="sm"
         aria-label="Submit a prompt"
         title="Submit a prompt"
-        onClick={() => {
-          setOpen(true);
-          setView("submit");
-          setError(null);
-        }}
+        onClick={() => setOpen(true)}
         className="fixed right-3 bottom-[72px] z-40 h-11 w-11 rounded-full border border-black/10 bg-gradient-to-b from-accent to-accent/80 p-0 shadow-[0_10px_20px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.35)] transition-[transform,box-shadow,filter] duration-150 hover:-translate-y-0.5 hover:shadow-[0_14px_24px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.4)] active:translate-y-0 active:shadow-[0_6px_14px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.25)] sm:right-4 sm:bottom-4"
       >
         <Sparkles size={14} aria-hidden />
       </Button>
 
-      {open &&
-        createPortal(
-          <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-            onClick={(e) => {
-              if (e.target === e.currentTarget) setOpen(false);
-            }}
-          >
-            <div
-              ref={dialogRef}
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="submit-prompt-title"
-              className="w-full max-w-3xl rounded-[8px] border border-border bg-background shadow-xl"
-            >
-              <div className="flex items-start justify-between border-b border-border px-5 py-4 sm:px-6 sm:py-5">
-                <div>
-                  <h2 id="submit-prompt-title" className="text-2xl font-semibold text-balance">
-                    {view === "submit" ? "Submit a prompt" : "Community prompts"}
-                  </h2>
-                  <p className="mt-1 max-w-2xl text-sm text-muted">
-                    {view === "submit"
-                      ? "Prompt a coding agent to build what you want to see in Straude. If we like your prompt, we'll run it and merge the result."
-                      : "Browse what people want us to build next."}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setOpen(false)}
-                  className="rounded-[4px] border border-border p-2 text-muted hover:text-foreground"
-                  aria-label="Close"
-                >
-                  <X size={16} />
-                </button>
-              </div>
-
-              {view === "submit" ? (
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    void handleSubmit();
-                  }}
-                  className="space-y-5 px-5 py-5 sm:px-6 sm:py-6"
-                >
-                  <div>
-                    <label htmlFor="prompt-input" className="mb-2 block text-base font-semibold">
-                      Prompt
-                    </label>
-                    <Textarea
-                      id="prompt-input"
-                      ref={textareaRef}
-                      rows={7}
-                      maxLength={MAX_PROMPT_LENGTH}
-                      placeholder={"What should we build or improve?\n\nIdeas to get started:\n- Feature request: \"Add keyboard shortcuts for editing posts\"\n- Bug fix: \"Comments flash as anonymous after posting\"\n- UI nitpick: \"Tighten spacing in the feed cards\"\n- Growth idea: \"Add a referral badge to help more people discover Straude\""}
-                      value={prompt}
-                      onChange={(e) => setPrompt(e.target.value)}
-                      onKeyDown={(e) => {
-                        if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                          e.preventDefault();
-                          void handleSubmit();
-                        }
-                      }}
-                      error={!!error}
-                    />
-                    <div className="mt-2 flex items-center justify-between text-xs text-muted">
-                      <span>Be specific about behavior, UX, and edge cases.</span>
-                      <span className="tabular-nums">
-                        {prompt.length}/{MAX_PROMPT_LENGTH}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-[4px] border border-border bg-subtle px-3 py-2">
-                    <p className="text-sm text-muted">
-                      {anonymous
-                        ? "Submitting as Anonymous"
-                        : username
-                          ? `Submitting as @${username}`
-                          : "Submitting with your account"}
-                    </p>
-                    <button
-                      type="button"
-                      onClick={() => setAnonymous((v) => !v)}
-                      className="text-sm font-medium text-accent hover:underline"
-                    >
-                      {anonymous ? "Submit with username" : "Submit as anonymous"}
-                    </button>
-                  </div>
-
-                  {error && (
-                    <p role="alert" className="text-sm text-error">
-                      {error}
-                    </p>
-                  )}
-
-                  <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void openCommunityView();
-                      }}
-                      className="text-left text-sm font-medium text-accent hover:underline"
-                    >
-                      View community prompts
-                    </button>
-                    <Button type="submit" disabled={submitting}>
-                      {submitting ? "Submitting..." : "Submit prompt ⌘↵"}
-                    </Button>
-                  </div>
-                </form>
-              ) : (
-                <div className="space-y-4 px-5 py-5 sm:px-6 sm:py-6">
-                  <div className="max-h-[420px] overflow-y-auto rounded-[4px] border border-border">
-                    {communityLoading ? (
-                      <p className="px-4 py-8 text-center text-sm text-muted">
-                        Loading community prompts...
-                      </p>
-                    ) : communityError ? (
-                      <p role="alert" className="px-4 py-8 text-center text-sm text-error">
-                        {communityError}
-                      </p>
-                    ) : communityPrompts.length === 0 ? (
-                      <p className="px-4 py-8 text-center text-sm text-muted">
-                        No prompts yet.
-                      </p>
-                    ) : (
-                      <div className="divide-y divide-border">
-                        {communityPrompts.map((row) => {
-                          const usernameValue = row.user?.username ?? null;
-                          const canLink = Boolean(usernameValue && !row.is_anonymous);
-                          return (
-                            <article key={row.id} className="px-4 py-4">
-                              <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-                                {canLink ? (
-                                  <Link
-                                    href={`/u/${usernameValue}`}
-                                    className="font-semibold text-accent hover:underline"
-                                  >
-                                    @{usernameValue}
-                                  </Link>
-                                ) : (
-                                  <span className="font-semibold text-muted">
-                                    {row.is_anonymous ? "Anonymous" : "Unknown user"}
-                                  </span>
-                                )}
-                                <span suppressHydrationWarning className="text-muted">
-                                  {timeAgo(row.created_at)}
-                                </span>
-                              </div>
-                              <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-                                {row.prompt}
-                              </p>
-                            </article>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center">
-                    <button
-                      type="button"
-                      onClick={() => setView("submit")}
-                      className="text-left text-sm font-medium text-accent hover:underline"
-                    >
-                      Back to submit a prompt
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>,
-          document.body,
-        )}
+      {open && (
+        <SubmitPromptModal
+          username={username}
+          onClose={() => setOpen(false)}
+          onSubmitted={(message) => {
+            setOpen(false);
+            setFlash(message);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/components/app/shared/CommandPalette.tsx
+++ b/apps/web/components/app/shared/CommandPalette.tsx
@@ -1,177 +1,77 @@
 "use client";
 
-import {
-  KBarProvider,
-  KBarPortal,
-  KBarPositioner,
-  KBarAnimator,
-  KBarSearch,
-  KBarResults,
-  useMatches,
-  type Action,
-} from "kbar";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useTheme } from "@/components/providers/ThemeProvider";
-import { createClient } from "@/lib/supabase/client";
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 
-const STATIC_PREFETCH_HREFS = [
-  "/feed",
-  "/leaderboard",
-  "/search",
-  "/settings",
-  "/post/new",
-  "/recap",
-  "/prompts",
-] as const;
+const CommandPaletteInner = dynamic(
+  () => import("@/components/app/shared/CommandPaletteInner").then((mod) => mod.CommandPaletteInner),
+  { ssr: false },
+);
 
-function RenderResults() {
-  const { results } = useMatches();
-
-  return (
-    <KBarResults
-      items={results}
-      onRender={({ item, active }) =>
-        typeof item === "string" ? (
-          <div className="px-4 py-2 text-xs uppercase text-muted">{item}</div>
-        ) : (
-          <div
-            className={`flex cursor-pointer items-center justify-between px-4 py-3 text-sm ${
-              active ? "bg-hover text-accent" : "text-foreground"
-            }`}
-          >
-            <span>{item.name}</span>
-            {item.shortcut && item.shortcut.length > 0 && (
-              <span className="flex gap-1">
-                {item.shortcut.map((key) => (
-                  <kbd
-                    key={key}
-                    className="rounded border border-border bg-subtle px-1.5 py-0.5 font-mono text-xs text-muted"
-                  >
-                    {key}
-                  </kbd>
-                ))}
-              </span>
-            )}
-          </div>
-        )
-      }
-    />
-  );
+interface CommandPaletteProps {
+  username?: string | null;
+  children: ReactNode;
 }
 
-export function CommandPalette({
-  username,
-  children,
-}: {
-  username?: string | null;
-  children: React.ReactNode;
-}) {
-  const router = useRouter();
-  const { setTheme } = useTheme();
-  const profileHref = username ? `/u/${username}` : "/feed";
+type WindowWithIdleCallback = Window & {
+  requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function isCommandPaletteShortcut(event: KeyboardEvent) {
+  return (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k";
+}
+
+export function CommandPalette({ username, children }: CommandPaletteProps) {
+  const [shouldLoad, setShouldLoad] = useState(false);
+  const [openOnLoad, setOpenOnLoad] = useState(false);
 
   useEffect(() => {
-    for (const href of STATIC_PREFETCH_HREFS) {
-      router.prefetch(href);
-    }
-    router.prefetch(profileHref);
-  }, [profileHref, router]);
+    if (shouldLoad) return;
 
-  const actions: Action[] = [
-    {
-      id: "feed",
-      name: "Feed",
-      shortcut: ["g", "f"],
-      perform: () => router.push("/feed"),
-    },
-    {
-      id: "leaderboard",
-      name: "Leaderboard",
-      shortcut: ["g", "l"],
-      perform: () => router.push("/leaderboard"),
-    },
-    {
-      id: "search",
-      name: "Search",
-      shortcut: ["/"],
-      perform: () => router.push("/search"),
-    },
-    {
-      id: "settings",
-      name: "Settings",
-      shortcut: ["g", "s"],
-      perform: () => router.push("/settings"),
-    },
-    {
-      id: "new-post",
-      name: "New Post",
-      shortcut: ["c"],
-      perform: () => router.push("/post/new"),
-    },
-    {
-      id: "recap",
-      name: "Recap",
-      shortcut: ["g", "r"],
-      perform: () => router.push("/recap"),
-    },
-    {
-      id: "prompts",
-      name: "Prompts",
-      shortcut: ["g", "p"],
-      perform: () => router.push("/prompts"),
-    },
-    {
-      id: "profile",
-      name: "Profile",
-      shortcut: ["g", "m"],
-      perform: () => router.push(profileHref),
-    },
-    {
-      id: "logout",
-      name: "Log out",
-      section: "Account",
-      shortcut: [],
-      perform: async () => {
-        const supabase = createClient();
-        await supabase.auth.signOut();
-        router.push("/");
-      },
-    },
-    {
-      id: "theme-light",
-      name: "Light theme",
-      section: "Theme",
-      shortcut: [],
-      perform: () => setTheme("light"),
-    },
-    {
-      id: "theme-dark",
-      name: "Dark theme",
-      section: "Theme",
-      shortcut: [],
-      perform: () => setTheme("dark"),
-    },
-    {
-      id: "theme-system",
-      name: "System theme",
-      section: "Theme",
-      shortcut: [],
-      perform: () => setTheme("system"),
-    },
-  ];
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!isCommandPaletteShortcut(event)) return;
+
+      event.preventDefault();
+      setOpenOnLoad(true);
+      setShouldLoad(true);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [shouldLoad]);
+
+  useEffect(() => {
+    if (shouldLoad) return;
+
+    const idleWindow = window as WindowWithIdleCallback;
+    if (idleWindow.requestIdleCallback) {
+      const idleId = idleWindow.requestIdleCallback(
+        () => setShouldLoad(true),
+        { timeout: 4_000 },
+      );
+      return () => idleWindow.cancelIdleCallback?.(idleId);
+    }
+
+    const timeoutId = window.setTimeout(() => setShouldLoad(true), 2_500);
+    return () => window.clearTimeout(timeoutId);
+  }, [shouldLoad]);
+
+  const handleOpenOnLoadConsumed = useCallback(() => {
+    setOpenOnLoad(false);
+  }, []);
+
+  if (!shouldLoad) {
+    return <>{children}</>;
+  }
 
   return (
-    <KBarProvider actions={actions}>
-      <KBarPortal>
-        <KBarPositioner className="z-50 bg-overlay">
-          <KBarAnimator className="mx-auto mt-[20vh] w-full max-w-[600px] rounded-[4px] border border-border bg-background">
-            <KBarSearch className="w-full border-b border-border bg-background px-4 py-3 font-mono text-base text-foreground outline-none placeholder:text-muted" />
-            <RenderResults />
-          </KBarAnimator>
-        </KBarPositioner>
-      </KBarPortal>
+    <CommandPaletteInner
+      username={username}
+      openOnLoad={openOnLoad}
+      onOpenOnLoadConsumed={handleOpenOnLoadConsumed}
+    >
       {children}
-    </KBarProvider>
+    </CommandPaletteInner>
   );
 }

--- a/apps/web/components/app/shared/CommandPaletteInner.tsx
+++ b/apps/web/components/app/shared/CommandPaletteInner.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import {
+  KBarProvider,
+  KBarPortal,
+  KBarPositioner,
+  KBarAnimator,
+  KBarSearch,
+  KBarResults,
+  useKBar,
+  useMatches,
+  type Action,
+} from "kbar";
+import { useEffect, useMemo, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "@/components/providers/ThemeProvider";
+import { createClient } from "@/lib/supabase/client";
+
+function RenderResults() {
+  const { results } = useMatches();
+
+  return (
+    <KBarResults
+      items={results}
+      onRender={({ item, active }) =>
+        typeof item === "string" ? (
+          <div className="px-4 py-2 text-xs uppercase text-muted">{item}</div>
+        ) : (
+          <div
+            className={`flex cursor-pointer items-center justify-between px-4 py-3 text-sm ${
+              active ? "bg-hover text-accent" : "text-foreground"
+            }`}
+          >
+            <span>{item.name}</span>
+            {item.shortcut && item.shortcut.length > 0 && (
+              <span className="flex gap-1">
+                {item.shortcut.map((key) => (
+                  <kbd
+                    key={key}
+                    className="rounded border border-border bg-subtle px-1.5 py-0.5 font-mono text-xs text-muted"
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </span>
+            )}
+          </div>
+        )
+      }
+    />
+  );
+}
+
+function OpenOnLoad({
+  open,
+  onConsumed,
+}: {
+  open: boolean;
+  onConsumed: () => void;
+}) {
+  const { query } = useKBar();
+
+  useEffect(() => {
+    if (!open) return;
+
+    query.toggle();
+    onConsumed();
+  }, [onConsumed, open, query]);
+
+  return null;
+}
+
+export function CommandPaletteInner({
+  username,
+  children,
+  openOnLoad = false,
+  onOpenOnLoadConsumed = () => {},
+}: {
+  username?: string | null;
+  children: ReactNode;
+  openOnLoad?: boolean;
+  onOpenOnLoadConsumed?: () => void;
+}) {
+  const router = useRouter();
+  const { setTheme } = useTheme();
+  const profileHref = username ? `/u/${username}` : "/feed";
+
+  const actions: Action[] = useMemo(
+    () => [
+      {
+        id: "feed",
+        name: "Feed",
+        shortcut: ["g", "f"],
+        perform: () => router.push("/feed"),
+      },
+      {
+        id: "leaderboard",
+        name: "Leaderboard",
+        shortcut: ["g", "l"],
+        perform: () => router.push("/leaderboard"),
+      },
+      {
+        id: "search",
+        name: "Search",
+        shortcut: ["/"],
+        perform: () => router.push("/search"),
+      },
+      {
+        id: "settings",
+        name: "Settings",
+        shortcut: ["g", "s"],
+        perform: () => router.push("/settings"),
+      },
+      {
+        id: "new-post",
+        name: "New Post",
+        shortcut: ["c"],
+        perform: () => router.push("/post/new"),
+      },
+      {
+        id: "recap",
+        name: "Recap",
+        shortcut: ["g", "r"],
+        perform: () => router.push("/recap"),
+      },
+      {
+        id: "prompts",
+        name: "Prompts",
+        shortcut: ["g", "p"],
+        perform: () => router.push("/prompts"),
+      },
+      {
+        id: "profile",
+        name: "Profile",
+        shortcut: ["g", "m"],
+        perform: () => router.push(profileHref),
+      },
+      {
+        id: "logout",
+        name: "Log out",
+        section: "Account",
+        shortcut: [],
+        perform: async () => {
+          const supabase = createClient();
+          await supabase.auth.signOut();
+          router.push("/");
+        },
+      },
+      {
+        id: "theme-light",
+        name: "Light theme",
+        section: "Theme",
+        shortcut: [],
+        perform: () => setTheme("light"),
+      },
+      {
+        id: "theme-dark",
+        name: "Dark theme",
+        section: "Theme",
+        shortcut: [],
+        perform: () => setTheme("dark"),
+      },
+      {
+        id: "theme-system",
+        name: "System theme",
+        section: "Theme",
+        shortcut: [],
+        perform: () => setTheme("system"),
+      },
+    ],
+    [profileHref, router, setTheme],
+  );
+
+  return (
+    <KBarProvider actions={actions}>
+      <OpenOnLoad open={openOnLoad} onConsumed={onOpenOnLoadConsumed} />
+      <KBarPortal>
+        <KBarPositioner className="z-50 bg-overlay">
+          <KBarAnimator className="mx-auto mt-[20vh] w-full max-w-[600px] rounded-[4px] border border-border bg-background">
+            <KBarSearch className="w-full border-b border-border bg-background px-4 py-3 font-mono text-base text-foreground outline-none placeholder:text-muted" />
+            <RenderResults />
+          </KBarAnimator>
+        </KBarPositioner>
+      </KBarPortal>
+      {children}
+    </KBarProvider>
+  );
+}

--- a/apps/web/components/app/shared/ResponsiveShellFrame.tsx
+++ b/apps/web/components/app/shared/ResponsiveShellFrame.tsx
@@ -15,6 +15,7 @@ interface ResponsiveShellFrameProps {
   leftPanel: ReactNode;
   rightPanel: ReactNode;
   children: ReactNode;
+  showPromptWidget?: boolean;
 }
 
 export function ResponsiveShellFrame({
@@ -23,6 +24,7 @@ export function ResponsiveShellFrame({
   leftPanel,
   rightPanel,
   children,
+  showPromptWidget = true,
 }: ResponsiveShellFrameProps) {
   const mode = useResponsiveShell();
   const [panelOpenMode, setPanelOpenMode] = useState<ResponsiveShellMode | null>(null);
@@ -122,7 +124,7 @@ export function ResponsiveShellFrame({
       </div>
 
       <MobileNav username={username} />
-      <SubmitPromptWidget username={username} />
+      {showPromptWidget && <SubmitPromptWidget username={username} />}
 
       <PanelSheet
         key={`${mode}-${panelTriggerLabel ?? "none"}`}

--- a/apps/web/components/app/shared/RightSidebar.tsx
+++ b/apps/web/components/app/shared/RightSidebar.tsx
@@ -1,116 +1,81 @@
-import { createClient } from "@/lib/supabase/server";
-import { getServiceClient } from "@/lib/supabase/service";
-import { formatTokens } from "@/lib/utils/format";
-import Link from "next/link";
-import { Avatar } from "@/components/ui/Avatar";
-import { FollowButton } from "@/components/app/profile/FollowButton";
+"use client";
 
-interface RightSidebarProps {
-  userId: string;
-  totalOutputTokens: number;
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { Avatar } from "@/components/ui/Avatar";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { FollowButton } from "@/components/app/profile/FollowButton";
+import { fetchRightSidebar, type RightSidebarResponse } from "@/lib/query/right-sidebar";
+import { queryKeys } from "@/lib/query/keys";
+import { formatTokens } from "@/lib/utils/format";
+
+export function RightSidebarFallback() {
+  return (
+    <div className="flex flex-col" aria-label="Loading discovery panel">
+      {[0, 1, 2].map((section) => (
+        <div key={section} className="border-b border-border p-6">
+          <Skeleton className="mb-4 h-3 w-28" />
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
-export async function RightSidebar({
-  userId,
-  totalOutputTokens,
-}: RightSidebarProps) {
-  const supabase = await createClient();
-  // Service client so suggestions can include all users.
-  const service = getServiceClient();
+export function LazyRightSidebar() {
+  const rightSidebarQuery = useQuery({
+    queryKey: queryKeys.rightSidebar(),
+    queryFn: fetchRightSidebar,
+    staleTime: 60_000,
+  });
 
-  // Start independent queries in parallel (avoid waterfall)
-  const [{ data: topUsers }, { data: following }] = await Promise.all([
-    supabase
-      .from("leaderboard_weekly")
-      .select("user_id, username, avatar_url, total_cost")
-      .order("total_cost", { ascending: false })
-      .limit(5),
-    supabase
-      .from("follows")
-      .select("following_id")
-      .eq("follower_id", userId),
-  ]);
-
-  const followingIds = following?.map((f) => f.following_id) ?? [];
-  const excludeIds = [userId, ...followingIds];
-
-  // Service client bypasses RLS so we can query all users for suggestions.
-  const [{ data: pinnedUsers }, { data: recentlyActive }, { data: newSignups }] =
-    await Promise.all([
-      service
-        .from("users")
-        .select("id, username, avatar_url, bio")
-        .eq("is_pinned_suggestion", true)
-        .not("id", "in", `(${excludeIds.join(",")})`),
-      // Users with recent activity (have pushed usage data)
-      service
-        .from("daily_usage")
-        .select("user_id, users!inner(id, username, avatar_url, bio, is_public)")
-        .not("users.username", "is", null)
-        .not("user_id", "in", `(${excludeIds.join(",")})`)
-        .order("date", { ascending: false })
-        .limit(20),
-      // New signups who completed onboarding (have a username)
-      service
-        .from("users")
-        .select("id, username, avatar_url, bio")
-        .eq("is_public", true)
-        .not("username", "is", null)
-        .not("id", "in", `(${excludeIds.join(",")})`)
-        .order("created_at", { ascending: false })
-        .limit(10),
-    ]);
-
-  const pinnedIds = new Set((pinnedUsers ?? []).map((u) => u.id));
-
-  // Deduplicate active users (may appear on multiple days), skip private and pinned
-  const seenIds = new Set<string>();
-  const activeUsers: Array<{ id: string; username: string; avatar_url: string | null; bio: string | null }> = [];
-  for (const row of recentlyActive ?? []) {
-    const u = row.users as unknown as { id: string; username: string; avatar_url: string | null; bio: string | null; is_public: boolean };
-    if (!seenIds.has(u.id) && !pinnedIds.has(u.id) && u.is_public) {
-      seenIds.add(u.id);
-      activeUsers.push({ id: u.id, username: u.username, avatar_url: u.avatar_url, bio: u.bio });
-    }
+  if (rightSidebarQuery.isLoading) {
+    return <RightSidebarFallback />;
   }
 
-  // Merge: active users first, then new signups, then pinned last (all deduped)
-  const merged: typeof activeUsers = [];
-  for (const u of activeUsers) {
-    if (!merged.some((m) => m.id === u.id)) merged.push(u);
+  if (rightSidebarQuery.isError) {
+    return (
+      <div className="border-b border-border p-6">
+        <p className="text-sm text-muted">Discovery is unavailable right now.</p>
+      </div>
+    );
   }
-  for (const u of newSignups ?? []) {
-    if (!merged.some((m) => m.id === u.id) && !pinnedIds.has(u.id)) merged.push(u);
-  }
-  // Cap organic suggestions to leave room for pinned users at the end
-  const pinnedList = (pinnedUsers ?? []).filter((u) => u.username);
-  const organicLimit = Math.max(0, 5 - pinnedList.length);
-  const suggested = [...merged.slice(0, organicLimit), ...pinnedList].slice(0, 5);
 
+  if (!rightSidebarQuery.data) {
+    return <RightSidebarFallback />;
+  }
+
+  return <RightSidebar data={rightSidebarQuery.data} />;
+}
+
+export function RightSidebar({ data }: { data: RightSidebarResponse }) {
   const TARGET = 1_000_000_000;
-  const pct = Math.min((totalOutputTokens / TARGET) * 100, 100);
+  const pct = Math.min((data.totalOutputTokens / TARGET) * 100, 100);
 
   return (
     <div className="flex flex-col">
-      {/* Suggested Friends */}
       <div className="border-b border-border p-6">
         <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted">
           Suggested Friends
         </p>
-        {suggested && suggested.length > 0 ? (
+        {data.suggested.length > 0 ? (
           <ul className="flex flex-col gap-3">
-            {suggested.map((u) => (
-              <li key={u.id} className="flex items-center gap-3">
-                <Link href={`/u/${u.username}`} className="flex items-center gap-3 flex-1 min-w-0 hover:text-accent">
-                  <Avatar src={u.avatar_url} alt={u.username ?? ""} size="sm" fallback={u.username ?? "?"} />
+            {data.suggested.map((user) => (
+              <li key={user.id} className="flex items-center gap-3">
+                <Link href={`/u/${user.username}`} className="flex min-w-0 flex-1 items-center gap-3 hover:text-accent">
+                  <Avatar src={user.avatar_url} alt={user.username} size="sm" fallback={user.username} />
                   <div className="flex-1 overflow-hidden">
-                    <p className="truncate text-sm font-medium">{u.username}</p>
-                    {u.bio && (
-                      <p className="truncate text-xs text-muted">{u.bio}</p>
+                    <p className="truncate text-sm font-medium">{user.username}</p>
+                    {user.bio && (
+                      <p className="truncate text-xs text-muted">{user.bio}</p>
                     )}
                   </div>
                 </Link>
-                <FollowButton username={u.username} initialFollowing={false} />
+                <FollowButton username={user.username} initialFollowing={false} />
               </li>
             ))}
           </ul>
@@ -119,7 +84,6 @@ export async function RightSidebar({
         )}
       </div>
 
-      {/* Featured Challenge */}
       <div className="border-b border-border p-6">
         <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted">
           Featured Challenge
@@ -127,7 +91,7 @@ export async function RightSidebar({
         <p className="text-sm font-semibold">The Three Comma Club</p>
         <p className="mb-3 text-xs text-muted">First to one billion output tokens</p>
         <div className="mb-1 flex items-center justify-between text-xs text-muted">
-          <span>{formatTokens(totalOutputTokens)} ({pct < 0.01 ? '<0.01' : pct.toFixed(2)}%)</span>
+          <span>{formatTokens(data.totalOutputTokens)} ({pct < 0.01 ? "<0.01" : pct.toFixed(2)}%)</span>
           <span>1B</span>
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-subtle">
@@ -138,32 +102,31 @@ export async function RightSidebar({
         </div>
       </div>
 
-      {/* Leaderboard Preview */}
       <div className="border-b border-border p-6">
         <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted">
           Top This Week
         </p>
         <ul className="flex flex-col gap-3">
-          {topUsers?.map((u, i) => (
-            <li key={u.user_id}>
+          {data.topUsers.map((user, index) => (
+            <li key={user.user_id}>
               <Link
-                href={`/u/${u.username}`}
+                href={`/u/${user.username ?? ""}`}
                 className="flex items-center gap-3 hover:text-accent"
               >
                 <span className="flex h-6 w-6 shrink-0 items-center justify-center text-xs font-semibold">
-                  {i + 1}
+                  {index + 1}
                 </span>
-                <Avatar src={u.avatar_url} alt={u.username ?? ""} size="sm" fallback={u.username ?? "?"} />
+                <Avatar src={user.avatar_url} alt={user.username ?? ""} size="sm" fallback={user.username ?? "?"} />
                 <span className="flex-1 truncate text-sm font-medium">
-                  {u.username}
+                  {user.username}
                 </span>
                 <span className="font-[family-name:var(--font-mono)] text-sm text-accent">
-                  ${Math.round(Number(u.total_cost)).toLocaleString("en-US")}
+                  ${Math.round(Number(user.total_cost ?? 0)).toLocaleString("en-US")}
                 </span>
               </Link>
             </li>
           ))}
-          {(!topUsers || topUsers.length === 0) && (
+          {data.topUsers.length === 0 && (
             <li className="text-sm text-muted">No activity yet</li>
           )}
         </ul>
@@ -175,7 +138,6 @@ export async function RightSidebar({
           <span className="text-base font-light">&rarr;</span>
         </Link>
       </div>
-
     </div>
   );
 }

--- a/apps/web/components/app/shared/TopHeader.tsx
+++ b/apps/web/components/app/shared/TopHeader.tsx
@@ -54,10 +54,13 @@ export function TopHeader({
   const notificationsQuery = useQuery({
     queryKey: queryKeys.notifications(),
     queryFn: fetchNotifications,
+    enabled: notifOpen,
+    staleTime: 30_000,
   });
   const appCountsQuery = useQuery({
     queryKey: queryKeys.appCounts(),
     queryFn: fetchAppCounts,
+    staleTime: 15_000,
   });
 
   const notifications = notificationsQuery.data?.notifications ?? [];
@@ -94,13 +97,16 @@ export function TopHeader({
     };
   }, [profileOpen, notifOpen]);
 
-  // Initial unread count fetch + mark as returning user + listen for external changes
+  // Initial unread count fetch + mark as returning user + listen for external changes.
+  // The full notifications list stays lazy until the menu is opened.
   useEffect(() => {
     function refreshCounts() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.appCounts() });
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.notifications(),
-      });
+      if (notifOpen) {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.notifications(),
+        });
+      }
     }
 
     try { localStorage.setItem("straude_returning", "1"); } catch {}
@@ -113,7 +119,7 @@ export function TopHeader({
       window.removeEventListener("notifications-updated", handleSync);
       window.removeEventListener("messages-updated", handleSync);
     };
-  }, [queryClient]);
+  }, [notifOpen, queryClient]);
 
   async function handleLogout() {
     const supabase = createClient();
@@ -207,16 +213,7 @@ export function TopHeader({
           <div ref={notifRef} className="relative">
             <button
               type="button"
-              onClick={() => {
-                setNotifOpen((v) => {
-                  if (!v) {
-                    void queryClient.invalidateQueries({
-                      queryKey: queryKeys.notifications(),
-                    });
-                  }
-                  return !v;
-                });
-              }}
+              onClick={() => setNotifOpen((v) => !v)}
               className="relative rounded p-1.5 text-muted hover:bg-subtle hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label="Notifications"
               aria-haspopup="true"
@@ -243,7 +240,15 @@ export function TopHeader({
                   )}
                 </div>
                 <div className="max-h-[60vh] overflow-y-auto sm:max-h-80" style={{ WebkitOverflowScrolling: "touch" }}>
-                  {notifications.length === 0 ? (
+                  {notificationsQuery.isLoading ? (
+                    <p className="px-4 py-6 text-center text-sm text-muted">
+                      Loading notifications...
+                    </p>
+                  ) : notificationsQuery.isError ? (
+                    <p role="alert" className="px-4 py-6 text-center text-sm text-error">
+                      Could not load notifications.
+                    </p>
+                  ) : notifications.length === 0 ? (
                     <p className="px-4 py-6 text-center text-sm text-muted">
                       No notifications yet
                     </p>

--- a/apps/web/components/providers/AppProviders.tsx
+++ b/apps/web/components/providers/AppProviders.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ConsentAwareAnalytics } from "@/components/providers/ConsentAwareAnalytics";
+import { PostHogClientProvider } from "@/components/providers/PostHogProvider";
+import { QueryProvider } from "@/components/providers/QueryProvider";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <PostHogClientProvider>
+      <QueryProvider>
+        <ThemeProvider>{children}</ThemeProvider>
+      </QueryProvider>
+      <ConsentAwareAnalytics />
+    </PostHogClientProvider>
+  );
+}

--- a/apps/web/components/providers/PostHogProvider.tsx
+++ b/apps/web/components/providers/PostHogProvider.tsx
@@ -10,6 +10,12 @@ import { useAnalyticsConsent } from "@/components/providers/useAnalyticsConsent"
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
+declare global {
+  interface Window {
+    __straudePostHogInitialized?: boolean;
+  }
+}
+
 /**
  * Wraps posthog-js/react PostHogProvider with deferred initialization.
  *
@@ -42,6 +48,7 @@ export function PostHogClientProvider({
       person_profiles: "identified_only",
     });
     initialized.current = true;
+    window.__straudePostHogInitialized = true;
     readyTimer = window.setTimeout(() => setReady(true), 0);
 
     const supabase = createClient();

--- a/apps/web/components/providers/PublicAnalytics.tsx
+++ b/apps/web/components/providers/PublicAnalytics.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { ConsentAwareAnalytics } from "@/components/providers/ConsentAwareAnalytics";
+import { useAnalyticsConsent } from "@/components/providers/useAnalyticsConsent";
+import { captureConsentedPostHogEvent } from "@/lib/analytics/client";
+
+export function PublicAnalytics() {
+  const analyticsConsent = useAnalyticsConsent();
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PublicPageviewTracker enabled={analyticsConsent} />
+      </Suspense>
+      <ConsentAwareAnalytics />
+    </>
+  );
+}
+
+function PublicPageviewTracker({ enabled }: { enabled: boolean }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [lastCapturedUrl, setLastCapturedUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !pathname) return;
+
+    const query = searchParams?.toString();
+    const path = query ? `${pathname}?${query}` : pathname;
+    const url = `${window.location.origin}${path}`;
+
+    if (url === lastCapturedUrl) return;
+    setLastCapturedUrl(url);
+
+    void captureConsentedPostHogEvent("$pageview", { $current_url: url });
+  }, [enabled, lastCapturedUrl, pathname, searchParams]);
+
+  return null;
+}

--- a/apps/web/lib/analytics/activation.ts
+++ b/apps/web/lib/analytics/activation.ts
@@ -60,6 +60,7 @@ export type ActivationEventProperties = Partial<{
   pricing_mode: string;
   ccusage_version: string;
   ccusage_agents: string[];
+  has_analytics_consent: boolean;
   has_existing_usage: boolean;
   has_errors: boolean;
   "$insert_id": string;
@@ -86,6 +87,7 @@ const ALLOWED_PROPERTY_KEYS = new Set([
   "pricing_mode",
   "ccusage_version",
   "ccusage_agents",
+  "has_analytics_consent",
   "has_existing_usage",
   "has_errors",
   "$insert_id",

--- a/apps/web/lib/analytics/client.ts
+++ b/apps/web/lib/analytics/client.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import posthog from "posthog-js";
 import {
   type ActivationEventName,
   type ActivationEventProperties,
@@ -8,12 +7,65 @@ import {
 } from "@/lib/analytics/activation";
 import { getCookieConsentFromCookieString } from "@/lib/cookie-consent";
 
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+declare global {
+  interface Window {
+    __straudePostHogInitialized?: boolean;
+  }
+}
+
+type PostHogClient = typeof import("posthog-js").default;
+
+let posthogPromise: Promise<PostHogClient | null> | null = null;
+
+function hasAnalyticsConsent() {
+  return getCookieConsentFromCookieString(document.cookie)?.analytics ?? false;
+}
+
+function getPostHogClient(): Promise<PostHogClient | null> {
+  if (!POSTHOG_KEY) return Promise.resolve(null);
+
+  posthogPromise ??= import("posthog-js")
+    .then((mod) => {
+      const posthog = mod.default;
+
+      if (!window.__straudePostHogInitialized) {
+        posthog.init(POSTHOG_KEY, {
+          api_host: "/ingest",
+          ui_host: "https://us.posthog.com",
+          defaults: "2025-05-24",
+          capture_pageview: false,
+          person_profiles: "identified_only",
+        });
+        window.__straudePostHogInitialized = true;
+      }
+
+      return posthog;
+    })
+    .catch(() => null);
+
+  return posthogPromise;
+}
+
+export async function captureConsentedPostHogEvent(
+  event: string,
+  properties: Record<string, unknown> = {},
+): Promise<void> {
+  if (!hasAnalyticsConsent()) return;
+
+  const posthog = await getPostHogClient();
+  posthog?.capture(event, properties);
+}
+
 export function trackActivationEvent(
   event: ActivationEventName,
   properties: ActivationEventProperties = {},
 ): void {
+  const analyticsConsent = hasAnalyticsConsent();
   const sanitized = sanitizeActivationProperties({
     source: "browser",
+    has_analytics_consent: analyticsConsent,
     ...properties,
   });
 
@@ -24,11 +76,5 @@ export function trackActivationEvent(
     keepalive: true,
   }).catch(() => {});
 
-  if (getCookieConsentFromCookieString(document.cookie)?.analytics) {
-    try {
-      posthog.capture(event, sanitized);
-    } catch {
-      // Browser analytics is best-effort; server lifecycle capture is primary.
-    }
-  }
+  void captureConsentedPostHogEvent(event, sanitized);
 }

--- a/apps/web/lib/data/usage-totals.ts
+++ b/apps/web/lib/data/usage-totals.ts
@@ -1,0 +1,62 @@
+import type { createClient } from "@/lib/supabase/server";
+import type { DailyUsage } from "@/types";
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+type UsageFallbackRow = Pick<DailyUsage, "cost_usd" | "output_tokens">;
+type UsageTotalsRpcRow = {
+  total_cost: number | string | null;
+  total_tokens: number | string | null;
+};
+
+export async function loadUsageTotals(
+  supabase: SupabaseServerClient,
+  userId: string,
+): Promise<{ totalTokens: number; totalCost: number }> {
+  const usageTotalsRes = await supabase
+    .rpc("get_user_usage_totals", { p_user_id: userId })
+    .single();
+
+  const loadFallbackUsageTotals = async (): Promise<{ totalTokens: number; totalCost: number }> => {
+    const { data: fallbackRows, error: fallbackError } = await supabase
+      .from("daily_usage")
+      .select("cost_usd, output_tokens")
+      .eq("user_id", userId);
+
+    if (fallbackError) {
+      throw new Error(`Unable to load usage totals from daily_usage fallback (${fallbackError.message})`);
+    }
+
+    const rows = (fallbackRows ?? []) as UsageFallbackRow[];
+    return {
+      totalTokens: rows.reduce((sum, row) => sum + Number(row.output_tokens), 0),
+      totalCost: rows.reduce((sum, row) => sum + Number(row.cost_usd), 0),
+    };
+  };
+
+  if (usageTotalsRes.error) {
+    console.error("get_user_usage_totals RPC failed; using direct daily_usage fallback", {
+      userId,
+      code: usageTotalsRes.error.code,
+      message: usageTotalsRes.error.message,
+    });
+
+    return loadFallbackUsageTotals();
+  }
+
+  const usageTotals = usageTotalsRes.data as UsageTotalsRpcRow | null;
+  const rpcTokens = usageTotals?.total_tokens;
+
+  if (rpcTokens === null || rpcTokens === undefined) {
+    console.error("get_user_usage_totals returned no total_tokens; using direct daily_usage fallback", {
+      userId,
+      rpcKeys: usageTotals ? Object.keys(usageTotals) : [],
+    });
+
+    return loadFallbackUsageTotals();
+  }
+
+  return {
+    totalTokens: Number(rpcTokens),
+    totalCost: Number(usageTotals?.total_cost ?? 0),
+  };
+}

--- a/apps/web/lib/query/keys.ts
+++ b/apps/web/lib/query/keys.ts
@@ -1,6 +1,7 @@
 export const queryKeys = {
   appBootstrap: () => ["app", "bootstrap"] as const,
   appCounts: () => ["app", "counts"] as const,
+  rightSidebar: () => ["app", "right-sidebar"] as const,
   notifications: (params?: {
     limit?: number;
     offset?: number;

--- a/apps/web/lib/query/right-sidebar.ts
+++ b/apps/web/lib/query/right-sidebar.ts
@@ -1,0 +1,29 @@
+export interface RightSidebarSuggestedUser {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+  bio: string | null;
+}
+
+export interface RightSidebarTopUser {
+  user_id: string;
+  username: string | null;
+  avatar_url: string | null;
+  total_cost: number | string | null;
+}
+
+export interface RightSidebarResponse {
+  suggested: RightSidebarSuggestedUser[];
+  topUsers: RightSidebarTopUser[];
+  totalOutputTokens: number;
+}
+
+export async function fetchRightSidebar(): Promise<RightSidebarResponse> {
+  const response = await fetch("/api/app/right-sidebar");
+
+  if (!response.ok) {
+    throw new Error("Failed to load right sidebar.");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- moves app-only providers out of the root layout so public/auth routes do not load the full authenticated shell stack
- adds lightweight PublicAnalytics for public/auth route groups while keeping consent-gated PostHog pageviews
- lazy-loads command palette and prompt modal code instead of putting them on the first app shell render path
- moves right sidebar discovery/totals queries behind /api/app/right-sidebar and fetches them lazily with React Query
- defers full notification list loading until the notifications menu opens

## Verification
- bun --cwd apps/web typecheck
- bun --cwd apps/web test -- __tests__/components/CommandPalette.test.tsx __tests__/components/SubmitPromptWidget.test.tsx __tests__/flows/activation-contract.test.ts
- bun --cwd apps/web build