### PR TITLE
Make CLI first sync faster

### DIFF
--- a/apps/web/__tests__/api/usage-submit.test.ts
+++ b/apps/web/__tests__/api/usage-submit.test.ts
@@ -357,7 +357,7 @@ describe("POST /api/usage/submit", () => {
     expect(json.error).toContain("Unsupported ccusage agents");
   });
 
-  it("rejects non-online ccusage pricing metadata", async () => {
+  it("rejects unsupported ccusage pricing metadata", async () => {
     (verifyCliToken as any).mockReturnValue("user-1");
     mockServiceClient();
 
@@ -1491,7 +1491,7 @@ describe("POST /api/usage/submit", () => {
           claude: "ccusage-claude-v20",
           ccusage_version: "20.0.6",
           ccusage_agents: ["claude"],
-          pricing_mode: "online",
+          pricing_mode: "offline",
         },
       })
     );
@@ -1500,7 +1500,7 @@ describe("POST /api/usage/submit", () => {
       claude: "ccusage-claude-v20",
       ccusage_version: "20.0.6",
       ccusage_agents: ["claude"],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     };
     expect(res.status).toBe(200);
     expect(svc.upsert.mock.calls[0][0].collector_meta).toEqual(expectedMeta);

--- a/apps/web/app/api/usage/submit/route.ts
+++ b/apps/web/app/api/usage/submit/route.ts
@@ -61,8 +61,12 @@ function validateEntry(entry: CcusageDailyEntry): string | null {
 
 function validateCollectorMeta(collector: UsageCollectorMeta | undefined): string | null {
   if (!collector) return null;
-  if (collector.pricing_mode != null && collector.pricing_mode !== "online") {
-    return "Unsupported pricing mode; ccusage submissions must use online pricing";
+  if (
+    collector.pricing_mode != null &&
+    collector.pricing_mode !== "online" &&
+    collector.pricing_mode !== "offline"
+  ) {
+    return "Unsupported pricing mode; ccusage submissions must use online or offline pricing";
   }
   if (collector.ccusage_agents != null) {
     if (!Array.isArray(collector.ccusage_agents)) {

--- a/packages/cli/__tests__/ccusage.test.ts
+++ b/packages/cli/__tests__/ccusage.test.ts
@@ -75,7 +75,7 @@ describe("parseCcusageOutput", () => {
       codex: CCUSAGE_CODEX_COLLECTOR,
       ccusage_version: "20.0.6",
       ccusage_agents: ["codex"],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     });
   });
 
@@ -104,7 +104,7 @@ describe("parseCcusageOutput", () => {
       codex: CCUSAGE_CODEX_COLLECTOR,
       ccusage_version: "20.0.6",
       ccusage_agents: ["claude", "codex"],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     });
     expect(parsed.data[0]!.reasoningOutputTokens).toBe(100);
   });
@@ -140,7 +140,7 @@ describe("parseCcusageOutput", () => {
     expect(parsed.collector).toEqual({
       ccusage_version: "20.0.6",
       ccusage_agents: [],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     });
   });
 
@@ -152,7 +152,7 @@ describe("parseCcusageOutput", () => {
 });
 
 describe("version and execution", () => {
-  it("invokes the installed ccusage binary with online unified daily args", async () => {
+  it("invokes the installed ccusage binary with offline unified daily args", async () => {
     execFileMock.mockImplementationOnce((...args: unknown[]) => {
       const cb = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
       cb(null, rawOutput(), "");
@@ -164,10 +164,30 @@ describe("version and execution", () => {
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock).toHaveBeenCalledWith(
       "/bundled/ccusage",
+      ["daily", "--json", "--since", "20260513", "--until", "20260513", "--offline"],
+      expect.objectContaining({ shell: false }),
+      expect.any(Function),
+    );
+    expect(collected.collector.pricing_mode).toBe("offline");
+  });
+
+  it("can explicitly collect with online pricing", async () => {
+    execFileMock.mockImplementationOnce((...args: unknown[]) => {
+      const cb = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
+      cb(null, rawOutput(), "");
+    });
+
+    const collected = await collectCcusageUsageAsync("20260513", "20260513", 10_000, {
+      pricingMode: "online",
+    });
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      "/bundled/ccusage",
       ["daily", "--json", "--since", "20260513", "--until", "20260513", "--no-offline"],
       expect.objectContaining({ shell: false }),
       expect.any(Function),
     );
+    expect(collected.collector.pricing_mode).toBe("online");
   });
 
   it("rejects ccusage versions below the v20 accuracy floor", async () => {
@@ -178,15 +198,35 @@ describe("version and execution", () => {
     );
   });
 
-  it("fails safely when ccusage reports missing online pricing", async () => {
+  it("falls back to online pricing when offline pricing is incomplete", async () => {
     execFileMock
       .mockImplementationOnce((...args: unknown[]) => {
         const cb = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
         cb(null, rawOutput(), "Missing pricing for model gpt-5.2-codex");
+      })
+      .mockImplementationOnce((...args: unknown[]) => {
+        const cb = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
+        cb(null, rawOutput(), "");
       });
 
-    await expect(collectCcusageUsageAsync("20260513", "20260513")).rejects.toThrow(
-      /fully priced online cost data/,
+    const collected = await collectCcusageUsageAsync("20260513", "20260513");
+
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(execFileMock.mock.calls[0]![1]).toContain("--offline");
+    expect(execFileMock.mock.calls[1]![1]).toContain("--no-offline");
+    expect(collected.collector.pricing_mode).toBe("online");
+  });
+
+  it("fails safely when the selected pricing mode remains incomplete", async () => {
+    execFileMock.mockImplementationOnce((...args: unknown[]) => {
+      const cb = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
+      cb(null, rawOutput(), "Missing pricing for model gpt-5.2-codex");
+    });
+
+    await expect(collectCcusageUsageAsync("20260513", "20260513", undefined, {
+      allowOnlineFallback: false,
+    })).rejects.toThrow(
+      /fully priced offline cost data/,
     );
   });
 });

--- a/packages/cli/__tests__/commands/push.test.ts
+++ b/packages/cli/__tests__/commands/push.test.ts
@@ -17,11 +17,14 @@ vi.mock("../../src/lib/api.js", () => ({
 vi.mock("../../src/lib/ccusage.js", () => ({
   CCUSAGE_CLAUDE_COLLECTOR: "ccusage-claude-v20",
   CCUSAGE_CODEX_COLLECTOR: "ccusage-codex-v20",
+  CCUSAGE_DEFAULT_PRICING_MODE: "offline",
   collectCcusageUsageAsync: vi.fn(),
 }));
 
 vi.mock("../../src/lib/telemetry.js", () => ({
   reportUsagePushFailed: vi.fn(),
+  shutdownTelemetryWithTimeout: vi.fn(() => Promise.resolve(0)),
+  TELEMETRY_SHUTDOWN_TIMEOUT_MS: 150,
   errorMessage: (error: unknown) => error instanceof Error ? error.message : String(error),
 }));
 
@@ -38,8 +41,7 @@ import { loadConfig, saveConfig, updateLastPushDate } from "../../src/lib/auth.j
 import { loginCommand } from "../../src/commands/login.js";
 import { apiRequest } from "../../src/lib/api.js";
 import { collectCcusageUsageAsync } from "../../src/lib/ccusage.js";
-import { posthog } from "../../src/lib/posthog.js";
-import { reportUsagePushFailed } from "../../src/lib/telemetry.js";
+import { reportUsagePushFailed, shutdownTelemetryWithTimeout } from "../../src/lib/telemetry.js";
 
 const mockLoadConfig = vi.mocked(loadConfig);
 const mockSaveConfig = vi.mocked(saveConfig);
@@ -47,8 +49,8 @@ const mockUpdateLastPushDate = vi.mocked(updateLastPushDate);
 const mockLoginCommand = vi.mocked(loginCommand);
 const mockApiRequest = vi.mocked(apiRequest);
 const mockCollectCcusageUsageAsync = vi.mocked(collectCcusageUsageAsync);
-const mockPosthog = vi.mocked(posthog);
 const mockReportUsagePushFailed = vi.mocked(reportUsagePushFailed);
+const mockShutdownTelemetry = vi.mocked(shutdownTelemetryWithTimeout);
 
 const fakeConfig = {
   token: "tok",
@@ -119,7 +121,7 @@ function ccusageOutput(entries = [usageEntry()], overrides: Record<string, unkno
       codex: "ccusage-codex-v20",
       ccusage_version: "20.0.6",
       ccusage_agents: ["claude", "codex"],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     },
     version: "20.0.6",
     raw: JSON.stringify({ daily: entries }),
@@ -169,6 +171,7 @@ describe("pushCommand", () => {
       expect.any(String),
       expect.any(String),
       undefined,
+      { pricingMode: "offline" },
     );
     expect(mockApiRequest).toHaveBeenCalledWith(
       expect.objectContaining(fakeConfig),
@@ -185,7 +188,7 @@ describe("pushCommand", () => {
       codex: "ccusage-codex-v20",
       ccusage_version: "20.0.6",
       ccusage_agents: ["claude", "codex"],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     });
     expect(body.device_id).toBe("device-1");
     expect(body.device_name).toBe("work-laptop");
@@ -213,10 +216,10 @@ describe("pushCommand", () => {
     expect(body.hash).toBe(concreteHash);
   });
 
-  it("runs one-time 30-day ccusage migration backfill and writes the new marker", async () => {
+  it("respects explicit --days even when the migration backfill marker is missing", async () => {
     const today = new Date();
-    const twentyNineDaysAgo = new Date(today);
-    twentyNineDaysAgo.setDate(today.getDate() - 29);
+    const twoDaysAgo = new Date(today);
+    twoDaysAgo.setDate(today.getDate() - 2);
     mockLoadConfig.mockReturnValue({
       ...fakeConfig,
       ccusage_v20_migration_completed_at: undefined,
@@ -226,9 +229,34 @@ describe("pushCommand", () => {
     await pushCommand({ days: 3 });
 
     expect(mockCollectCcusageUsageAsync).toHaveBeenCalledWith(
+      compact(twoDaysAgo),
+      compact(today),
+      undefined,
+      { pricingMode: "offline" },
+    );
+    expect(mockUpdateLastPushDate).toHaveBeenCalledWith(todayStr());
+    expect(mockSaveConfig).not.toHaveBeenCalledWith(expect.objectContaining({
+      ccusage_v20_migration_completed_at: expect.any(String),
+    }));
+  });
+
+  it("marks the ccusage v20 migration complete after an explicit 30-day backfill", async () => {
+    const today = new Date();
+    const twentyNineDaysAgo = new Date(today);
+    twentyNineDaysAgo.setDate(today.getDate() - 29);
+    mockLoadConfig.mockReturnValue({
+      ...fakeConfig,
+      ccusage_v20_migration_completed_at: undefined,
+      last_push_date: daysAgoStr(2),
+    });
+
+    await pushCommand({ days: 30 });
+
+    expect(mockCollectCcusageUsageAsync).toHaveBeenCalledWith(
       compact(twentyNineDaysAgo),
       compact(today),
       undefined,
+      { pricingMode: "offline" },
     );
     expect(mockSaveConfig).toHaveBeenLastCalledWith(expect.objectContaining({
       ccusage_v20_migration_completed_at: expect.any(String),
@@ -247,7 +275,9 @@ describe("pushCommand", () => {
 
     await pushCommand({ date: "2026-03-12" });
 
-    expect(mockCollectCcusageUsageAsync).toHaveBeenCalledWith("20260312", "20260312", undefined);
+    expect(mockCollectCcusageUsageAsync).toHaveBeenCalledWith("20260312", "20260312", undefined, {
+      pricingMode: "offline",
+    });
     expect(mockUpdateLastPushDate).toHaveBeenCalledWith(todayStr());
     expect(mockSaveConfig).not.toHaveBeenCalledWith(expect.objectContaining({
       ccusage_v20_migration_completed_at: expect.any(String),
@@ -260,6 +290,7 @@ describe("pushCommand", () => {
       expect.any(String),
       expect.any(String),
       300_000,
+      { pricingMode: "offline" },
     );
   });
 
@@ -301,9 +332,15 @@ describe("pushCommand", () => {
     expect(mockReportUsagePushFailed).toHaveBeenCalledWith(
       expect.objectContaining(fakeConfig),
       error,
-      { command: "push", stage: "scan" },
+      expect.objectContaining({
+        command: "push",
+        stage: "scan",
+        pricing_mode: "offline",
+        collection_ms: expect.any(Number),
+        total_ms: expect.any(Number),
+      }),
     );
-    expect(mockPosthog._shutdown).toHaveBeenCalled();
+    expect(mockShutdownTelemetry).toHaveBeenCalled();
     expect(mockApiRequest).not.toHaveBeenCalled();
   });
 
@@ -316,7 +353,14 @@ describe("pushCommand", () => {
     expect(mockReportUsagePushFailed).toHaveBeenCalledWith(
       expect.objectContaining(fakeConfig),
       error,
-      { command: "push", stage: "submit" },
+      expect.objectContaining({
+        command: "push",
+        stage: "submit",
+        pricing_mode: "offline",
+        collection_ms: expect.any(Number),
+        submit_ms: expect.any(Number),
+        total_ms: expect.any(Number),
+      }),
     );
     expect(process.exit).toHaveBeenCalledWith(1);
   });
@@ -355,7 +399,7 @@ describe("pushCommand", () => {
       collector: {
         ccusage_version: "20.0.6",
         ccusage_agents: [],
-        pricing_mode: "online",
+        pricing_mode: "offline",
       },
       raw: '{"daily":[]}',
     }) as never);

--- a/packages/cli/__tests__/flows/cli-sync-flow.test.ts
+++ b/packages/cli/__tests__/flows/cli-sync-flow.test.ts
@@ -146,7 +146,7 @@ describe("unified ccusage CLI flow", () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       "/bundled/ccusage",
-      expect.arrayContaining(["daily", "--json", "--no-offline"]),
+      expect.arrayContaining(["daily", "--json", "--offline"]),
       expect.any(Object),
       expect.any(Function),
     );
@@ -159,12 +159,12 @@ describe("unified ccusage CLI flow", () => {
       codex: "ccusage-codex-v20",
       ccusage_version: TEST_CCUSAGE_VERSION,
       ccusage_agents: ["claude", "codex"],
-      pricing_mode: "online",
+      pricing_mode: "offline",
     });
     expect(readPersistedConfig().last_push_date).toBe(todayStr());
   });
 
-  it("first migrated push backfills 30 days and stores ccusage_v20_migration_completed_at", async () => {
+  it("respects explicit --days before the migration backfill has completed", async () => {
     seedConfig({
       ccusage_v20_migration_completed_at: undefined,
       last_push_date: "2026-03-01",
@@ -172,6 +172,24 @@ describe("unified ccusage CLI flow", () => {
     mockSuccessfulSubmit();
 
     await pushCommand({ days: 3 });
+
+    const dailyCall = execFileMock.mock.calls.find(([, args]) =>
+      Array.isArray(args) && args.includes("daily"),
+    )!;
+    const args = dailyCall[1] as string[];
+    const since = args[args.indexOf("--since") + 1];
+    expect(since).toBe("20260311");
+    expect(readPersistedConfig().ccusage_v20_migration_completed_at).toBeUndefined();
+  });
+
+  it("marks the migration complete after explicit 30-day backfill", async () => {
+    seedConfig({
+      ccusage_v20_migration_completed_at: undefined,
+      last_push_date: "2026-03-01",
+    });
+    mockSuccessfulSubmit();
+
+    await pushCommand({ days: 30 });
 
     const dailyCall = execFileMock.mock.calls.find(([, args]) =>
       Array.isArray(args) && args.includes("daily"),

--- a/packages/cli/__tests__/resolve-push-date-range.test.ts
+++ b/packages/cli/__tests__/resolve-push-date-range.test.ts
@@ -86,19 +86,20 @@ describe("resolvePushDateRange", () => {
   });
 
   describe("ccusage migration branch", () => {
-    it("backfills the full 30-day window when ccusage migration runs", () => {
+    it("does not expand a normal sync to 30 days when the migration marker is missing", () => {
       const r = resolvePushDateRange({
         today: dateAt("2026-05-04"),
         options: {},
+        lastPushDate: "2026-05-01",
         shouldRunMigrationBackfill: true,
       });
       expect(r.ok).toBe(true);
       if (!r.ok) return;
-      expect(isoDay(r.since)).toBe("2026-04-05"); // today - 29 days
+      expect(isoDay(r.since)).toBe("2026-05-01");
       expect(isoDay(r.until)).toBe("2026-05-04");
     });
 
-    it("ignores --days when ccusage migration runs", () => {
+    it("respects --days when the migration marker is missing", () => {
       const r = resolvePushDateRange({
         today: dateAt("2026-05-04"),
         options: { days: 5 },
@@ -106,7 +107,7 @@ describe("resolvePushDateRange", () => {
       });
       expect(r.ok).toBe(true);
       if (!r.ok) return;
-      expect(isoDay(r.since)).toBe("2026-04-05"); // 30-day backfill, not 5
+      expect(isoDay(r.since)).toBe("2026-04-30");
     });
   });
 

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -80,6 +80,7 @@ export async function loginCommand(apiUrlOverride?: string): Promise<void> {
 
   openBrowser(verify_url);
   console.log(`\nIf the browser didn't open, visit:\n  ${verify_url}\n`);
+  console.log("Confirm in the browser, then keep this terminal open — Straude will continue syncing here.");
   process.stdout.write("Waiting for confirmation...");
 
   const startTime = Date.now();

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { hostname } from "node:os";
+import { performance } from "node:perf_hooks";
 import { loadConfig, updateLastPushDate, saveConfig } from "../lib/auth.js";
 import type { StraudeConfig } from "../lib/auth.js";
 import { loginCommand } from "./login.js";
@@ -7,6 +8,7 @@ import { apiRequest } from "../lib/api.js";
 import {
   CCUSAGE_CLAUDE_COLLECTOR,
   CCUSAGE_CODEX_COLLECTOR,
+  CCUSAGE_DEFAULT_PRICING_MODE,
   collectCcusageUsageAsync,
 } from "../lib/ccusage.js";
 import type { CcusageDailyEntry, CcusageCollectorMeta } from "../lib/ccusage.js";
@@ -15,7 +17,12 @@ import { Spinner } from "../lib/spinner.js";
 import type { DashboardData as DashboardResponse } from "../components/PushSummary.js";
 import { posthog } from "../lib/posthog.js";
 import { getDistinctId } from "../lib/machine-id.js";
-import { errorMessage, reportUsagePushFailed } from "../lib/telemetry.js";
+import {
+  TELEMETRY_SHUTDOWN_TIMEOUT_MS,
+  errorMessage,
+  reportUsagePushFailed,
+  shutdownTelemetryWithTimeout,
+} from "../lib/telemetry.js";
 
 interface UsageSubmitRequest {
   entries: Array<{
@@ -53,6 +60,28 @@ interface PushOptions {
   days?: number;
   dryRun?: boolean;
   timeoutMs?: number;
+  dashboardTimeoutMs?: number;
+}
+
+const DASHBOARD_TIMEOUT_MS = 1_500;
+
+type PushRangeMode =
+  | "explicit_date"
+  | "explicit_days"
+  | "incremental"
+  | "first_sync";
+
+interface PushTimings {
+  auth_ms?: number;
+  collection_ms?: number;
+  submit_ms?: number;
+  dashboard_ms?: number;
+}
+
+interface DashboardRenderResult {
+  rendered: boolean;
+  timedOut: boolean;
+  durationMs: number;
 }
 
 function formatDate(d: Date): string {
@@ -102,7 +131,7 @@ export function isWithinBackfillWindow(dateStr: string): boolean {
 }
 
 export type DateRangeResolution =
-  | { ok: true; since: Date; until: Date }
+  | { ok: true; since: Date; until: Date; mode: PushRangeMode }
   | { ok: false; error: string };
 
 /**
@@ -117,7 +146,7 @@ export function resolvePushDateRange(args: {
   lastPushDate?: string;
   shouldRunMigrationBackfill: boolean;
 }): DateRangeResolution {
-  const { today, options, lastPushDate, shouldRunMigrationBackfill } = args;
+  const { today, options, lastPushDate } = args;
   const todayStr = formatDate(today);
 
   if (options.date) {
@@ -128,40 +157,34 @@ export function resolvePushDateRange(args: {
     if (target > today) {
       return { ok: false, error: "Cannot push usage for a future date." };
     }
-    return { ok: true, since: target, until: target };
-  }
-
-  if (shouldRunMigrationBackfill) {
-    const since = new Date(today);
-    since.setDate(since.getDate() - MAX_BACKFILL_DAYS + 1);
-    return { ok: true, since, until: today };
+    return { ok: true, since: target, until: target, mode: "explicit_date" };
   }
 
   if (options.days) {
     const days = Math.min(options.days, MAX_BACKFILL_DAYS);
     const since = new Date(today);
     since.setDate(since.getDate() - days + 1);
-    return { ok: true, since, until: today };
+    return { ok: true, since, until: today, mode: "explicit_days" };
   }
 
   if (lastPushDate) {
     if (lastPushDate >= todayStr) {
-      return { ok: true, since: new Date(today), until: new Date(today) };
+      return { ok: true, since: new Date(today), until: new Date(today), mode: "incremental" };
     }
     const gap = daysBetweenStrings(lastPushDate, todayStr);
     if (gap > DEFAULT_SYNC_DAYS) {
       const since = new Date(today);
       since.setDate(since.getDate() - DEFAULT_SYNC_DAYS + 1);
-      return { ok: true, since, until: today };
+      return { ok: true, since, until: today, mode: "incremental" };
     }
-    return { ok: true, since: parseDate(lastPushDate), until: today };
+    return { ok: true, since: parseDate(lastPushDate), until: today, mode: "incremental" };
   }
 
   // Never pushed before — backfill last 3 days by default
   const FIRST_RUN_BACKFILL_DAYS = 3;
   const since = new Date(today);
   since.setDate(since.getDate() - FIRST_RUN_BACKFILL_DAYS + 1);
-  return { ok: true, since, until: today };
+  return { ok: true, since, until: today, mode: "first_sync" };
 }
 
 function formatTokens(n: number): string {
@@ -174,12 +197,147 @@ function formatCost(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
+function elapsedMs(start: number): number {
+  return Math.round(performance.now() - start);
+}
+
+function inclusiveDayCount(since: Date, until: Date): number {
+  return daysBetween(since, until) + 1;
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural;
+}
+
+function pushTelemetryProperties(args: {
+  timings: PushTimings;
+  totalStartedAt: number;
+  rangeMode: PushRangeMode;
+  firstRun: boolean;
+  authFlowStarted: boolean;
+  migrationPending: boolean;
+  fullBackfillCompleted: boolean;
+  pricingMode?: CcusageCollectorMeta["pricing_mode"];
+  ccusageVersion?: string;
+  ccusageAgents?: CcusageCollectorMeta["ccusage_agents"];
+  dashboardRendered?: boolean;
+  dashboardTimedOut?: boolean;
+}): Record<string, string | number | boolean | string[] | undefined> {
+  return {
+    first_run: args.firstRun,
+    auth_flow_started: args.authFlowStarted,
+    backfill_mode: args.rangeMode,
+    migration_backfill_pending: args.migrationPending,
+    full_backfill_completed: args.fullBackfillCompleted,
+    pricing_mode: args.pricingMode,
+    ccusage_version: args.ccusageVersion,
+    ccusage_agents: args.ccusageAgents,
+    dashboard_rendered: args.dashboardRendered,
+    dashboard_timed_out: args.dashboardTimedOut,
+    telemetry_shutdown_timeout_ms: TELEMETRY_SHUTDOWN_TIMEOUT_MS,
+    total_ms: elapsedMs(args.totalStartedAt),
+    ...args.timings,
+  };
+}
+
+async function renderDashboardWithTimeout(
+  config: StraudeConfig,
+  results: UsageSubmitResponse["results"] | undefined,
+  timeoutMs = DASHBOARD_TIMEOUT_MS,
+): Promise<DashboardRenderResult> {
+  const startedAt = performance.now();
+  const abortController = new AbortController();
+  let timer: NodeJS.Timeout | undefined;
+  let unmountDashboard: (() => void) | undefined;
+
+  const dashboardTask = (async () => {
+    const dashboard = await apiRequest<DashboardResponse>(config, "/api/cli/dashboard", {
+      signal: abortController.signal,
+    });
+    const { render } = await import("ink");
+    const { createElement } = await import("react");
+    const { PushSummary } = await import("../components/PushSummary.js");
+
+    const { waitUntilExit, unmount } = render(
+      createElement(PushSummary, {
+        dashboard,
+        results,
+      }),
+    );
+    unmountDashboard = unmount;
+    await waitUntilExit();
+  })();
+
+  const timeoutTask = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    const winner = await Promise.race([
+      dashboardTask.then(() => "rendered" as const).catch(() => "failed" as const),
+      timeoutTask,
+    ]);
+
+    if (winner === "timeout") {
+      abortController.abort();
+      unmountDashboard?.();
+    }
+
+    return {
+      rendered: winner === "rendered",
+      timedOut: winner === "timeout",
+      durationMs: elapsedMs(startedAt),
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+    dashboardTask.catch(() => {
+      // The command has already moved on after timeout/failure.
+    });
+  }
+}
+
+function printSubmitSuccess(args: {
+  entries: CcusageDailyEntry[];
+  results: UsageSubmitResponse["results"];
+  totalCost: number;
+  totalTokens: number;
+  migrationPending: boolean;
+  fullBackfillCompleted: boolean;
+}): void {
+  const { entries, results, totalCost, totalTokens, migrationPending, fullBackfillCompleted } = args;
+  const created = results.filter((r) => r.action === "created").length;
+  const updated = results.filter((r) => r.action === "updated").length;
+  const primaryResult = results[0];
+
+  console.log("");
+  console.log(
+    `Synced ${entries.length} ${pluralize(entries.length, "day")} (${formatCost(totalCost)}, ${formatTokens(totalTokens)} tokens).`,
+  );
+  if (created > 0 || updated > 0) {
+    console.log(`Posted ${created}, updated ${updated}.`);
+  }
+  if (primaryResult) {
+    console.log(`View it: ${primaryResult.post_url}${primaryResult.post_url.includes("?") ? "&" : "?"}edit=1`);
+  }
+  if (migrationPending && !fullBackfillCompleted) {
+    console.log(`Optional: backfill your last ${MAX_BACKFILL_DAYS} days with \`straude push --days ${MAX_BACKFILL_DAYS}\`.`);
+  }
+}
+
 export async function pushCommand(options: PushOptions, apiUrlOverride?: string): Promise<void> {
+  const totalStartedAt = performance.now();
+  const timings: PushTimings = {};
+  let authFlowStarted = false;
   let config = loadConfig();
 
   // Login if needed
   if (!config) {
+    authFlowStarted = true;
+    const authStartedAt = performance.now();
+    console.log("After authentication, Straude will continue into your first sync here.");
     await loginCommand(apiUrlOverride);
+    timings.auth_ms = elapsedMs(authStartedAt);
     config = loadConfig();
     if (!config) {
       console.error("Login failed.");
@@ -200,15 +358,14 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
   }
 
   const today = new Date();
-  // Trigger a one-time 30-day backfill after migrating both Claude and Codex
-  // ingestion to ccusage v20. Explicit --date pushes stay exact.
-  const shouldRunMigrationBackfill = !options.date && !config.ccusage_v20_migration_completed_at;
+  const migrationPending = !config.ccusage_v20_migration_completed_at;
+  const firstRun = !config.last_push_date;
 
   const resolution = resolvePushDateRange({
     today,
     options: { date: options.date, days: options.days },
     lastPushDate: config.last_push_date,
-    shouldRunMigrationBackfill,
+    shouldRunMigrationBackfill: migrationPending,
   });
   if (!resolution.ok) {
     console.error(resolution.error);
@@ -216,6 +373,8 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
   }
   const sinceDate = resolution.since;
   const untilDate = resolution.until;
+  const rangeMode = resolution.mode;
+  const fullBackfillRequested = inclusiveDayCount(sinceDate, untilDate) >= MAX_BACKFILL_DAYS;
 
   const sinceStr = formatDateCompact(sinceDate);
   const untilStr = formatDateCompact(untilDate);
@@ -229,16 +388,31 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
   const scanSpinner = new Spinner("scan");
   scanSpinner.start();
   let ccusage: Awaited<ReturnType<typeof collectCcusageUsageAsync>>;
+  const collectionStartedAt = performance.now();
   try {
-    ccusage = await collectCcusageUsageAsync(sinceStr, untilStr, options.timeoutMs);
+    ccusage = await collectCcusageUsageAsync(sinceStr, untilStr, options.timeoutMs, {
+      pricingMode: CCUSAGE_DEFAULT_PRICING_MODE,
+    });
+    timings.collection_ms = elapsedMs(collectionStartedAt);
     scanSpinner.stop();
   } catch (err) {
+    timings.collection_ms = elapsedMs(collectionStartedAt);
     scanSpinner.stop();
     reportUsagePushFailed(config, err, {
       command: "push",
       stage: "scan",
+      ...pushTelemetryProperties({
+        timings,
+        totalStartedAt,
+        rangeMode,
+        firstRun,
+        authFlowStarted,
+        migrationPending,
+        fullBackfillCompleted: false,
+        pricingMode: CCUSAGE_DEFAULT_PRICING_MODE,
+      }),
     });
-    await posthog._shutdown();
+    await shutdownTelemetryWithTimeout();
     console.error(`\nFailed to collect usage: ${errorMessage(err)}`);
     process.exit(1);
   }
@@ -314,22 +488,50 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
   const syncSpinner = new Spinner("sync");
   syncSpinner.start();
   let response: UsageSubmitResponse;
+  const submitStartedAt = performance.now();
   try {
     response = await apiRequest<UsageSubmitResponse>(config, "/api/usage/submit", {
       method: "POST",
       body: JSON.stringify(body),
     });
+    timings.submit_ms = elapsedMs(submitStartedAt);
     syncSpinner.stop();
   } catch (err) {
+    timings.submit_ms = elapsedMs(submitStartedAt);
     syncSpinner.stop();
     reportUsagePushFailed(config, err, {
       command: "push",
       stage: "submit",
+      ...pushTelemetryProperties({
+        timings,
+        totalStartedAt,
+        rangeMode,
+        firstRun,
+        authFlowStarted,
+        migrationPending,
+        fullBackfillCompleted: false,
+        pricingMode: ccusage.collector.pricing_mode,
+        ccusageVersion: ccusage.version,
+        ccusageAgents: ccusage.agents,
+      }),
     });
-    await posthog._shutdown();
+    await shutdownTelemetryWithTimeout();
     console.error(`\nFailed to submit: ${errorMessage(err)}`);
     process.exit(1);
   }
+
+  const totalCost = entries.reduce((sum, e) => sum + e.costUSD, 0);
+  const totalTokens = entries.reduce((sum, e) => sum + e.totalTokens, 0);
+  const fullBackfillCompleted = migrationPending && fullBackfillRequested;
+
+  printSubmitSuccess({
+    entries,
+    results: response.results,
+    totalCost,
+    totalTokens,
+    migrationPending,
+    fullBackfillCompleted,
+  });
 
   // Show per-entry delta feedback before dashboard
   for (const result of response.results) {
@@ -352,7 +554,7 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
     (latest, e) => (e.date > latest ? e.date : latest),
     entries[0]!.date,
   );
-  if (shouldRunMigrationBackfill) {
+  if (fullBackfillCompleted) {
     const stamp = new Date().toISOString();
     config.ccusage_v20_migration_completed_at = stamp;
     config.last_push_date = latestDate;
@@ -361,10 +563,19 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
     updateLastPushDate(latestDate);
   }
 
-  const totalCost = entries.reduce((sum, e) => sum + e.costUSD, 0);
-  const totalTokens = entries.reduce((sum, e) => sum + e.totalTokens, 0);
   const datesCreated = response.results.filter((r) => r.action === "created").length;
   const datesUpdated = response.results.filter((r) => r.action === "updated").length;
+
+  const dashboard = await renderDashboardWithTimeout(
+    config,
+    response.results,
+    options.dashboardTimeoutMs,
+  );
+  timings.dashboard_ms = dashboard.durationMs;
+  if (dashboard.timedOut) {
+    console.log(`Dashboard took too long to load. Run \`straude status\` anytime for the full view.`);
+  }
+
   posthog.capture({
     distinctId: getDistinctId(config),
     event: "usage_pushed",
@@ -375,31 +586,20 @@ export async function pushCommand(options: PushOptions, apiUrlOverride?: string)
       total_cost_usd: Math.round(totalCost * 100) / 100,
       total_tokens: totalTokens,
       dry_run: false,
-      ccusage_version: ccusage.version,
-      ccusage_agents: ccusage.agents,
+      ...pushTelemetryProperties({
+        timings,
+        totalStartedAt,
+        rangeMode,
+        firstRun,
+        authFlowStarted,
+        migrationPending,
+        fullBackfillCompleted,
+        pricingMode: ccusage.collector.pricing_mode,
+        ccusageVersion: ccusage.version,
+        ccusageAgents: ccusage.agents,
+        dashboardRendered: dashboard.rendered,
+        dashboardTimedOut: dashboard.timedOut,
+      }),
     },
   });
-
-  // Render visual dashboard
-  try {
-    const dashboard = await apiRequest<DashboardResponse>(config, "/api/cli/dashboard");
-    const { render } = await import("ink");
-    const { createElement } = await import("react");
-    const { PushSummary } = await import("../components/PushSummary.js");
-
-    const { waitUntilExit } = render(
-      createElement(PushSummary, {
-        dashboard,
-        results: response.results,
-      }),
-    );
-    await waitUntilExit();
-  } catch {
-    // Fallback: if dashboard fetch or Ink render fails, show plain text
-    console.log("");
-    for (const result of response.results) {
-      const verb = result.action === "updated" ? "Updated" : "Posted";
-      console.log(`${verb} ${result.date}: ${result.post_url}?edit=1`);
-    }
-  }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
   isPushInvocation,
   reportCliException,
   reportUsagePushFailed,
+  shutdownTelemetryWithTimeout,
 } from "./lib/telemetry.js";
 
 // On 401, transparently re-run the browser login flow and let api.ts retry
@@ -227,21 +228,6 @@ async function main(): Promise<void> {
 }
 
 let exitCode = 0;
-
-async function shutdownTelemetryWithTimeout(): Promise<void> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    await Promise.race([
-      posthog._shutdown(),
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, 500);
-        timer.unref?.();
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
 
 main()
   .catch((err: unknown) => {

--- a/packages/cli/src/lib/ccusage.ts
+++ b/packages/cli/src/lib/ccusage.ts
@@ -6,7 +6,12 @@ import { DEFAULT_SUBPROCESS_TIMEOUT_MS } from "../config.js";
 export const CCUSAGE_MIN_VERSION = "20.0.5";
 export const CCUSAGE_CLAUDE_COLLECTOR = "ccusage-claude-v20" as const;
 export const CCUSAGE_CODEX_COLLECTOR = "ccusage-codex-v20" as const;
-export const CCUSAGE_PRICING_MODE = "online" as const;
+export const CCUSAGE_DEFAULT_PRICING_MODE = "offline" as const;
+export const CCUSAGE_FALLBACK_PRICING_MODE = "online" as const;
+
+export type CcusagePricingMode =
+  | typeof CCUSAGE_DEFAULT_PRICING_MODE
+  | typeof CCUSAGE_FALLBACK_PRICING_MODE;
 
 const SUPPORTED_AGENTS = ["claude", "codex"] as const;
 const MAX_CCUSAGE_BUFFER = 20 * 1024 * 1024;
@@ -63,7 +68,7 @@ export interface CcusageCollectorMeta {
   codex?: typeof CCUSAGE_CODEX_COLLECTOR;
   ccusage_version: string;
   ccusage_agents: CcusageAgent[];
-  pricing_mode: typeof CCUSAGE_PRICING_MODE;
+  pricing_mode: CcusagePricingMode;
 }
 
 export interface CcusageOutput {
@@ -87,6 +92,12 @@ export interface CcusageOutput {
 interface ParseOptions {
   version?: string;
   stderr?: string;
+  pricingMode?: CcusagePricingMode;
+}
+
+interface CollectOptions {
+  pricingMode?: CcusagePricingMode;
+  allowOnlineFallback?: boolean;
 }
 
 interface CcusageRawEntry {
@@ -253,10 +264,14 @@ function execCcusageAsync(args: string[], timeoutMs?: number): Promise<ExecResul
   });
 }
 
-function rejectMissingPricing(stderr: string): void {
-  if (MISSING_PRICING_RE.test(stderr)) {
+function hasMissingPricingWarning(stderr: string): boolean {
+  return MISSING_PRICING_RE.test(stderr);
+}
+
+function rejectMissingPricing(stderr: string, pricingMode: CcusagePricingMode): void {
+  if (hasMissingPricingWarning(stderr)) {
     throw new Error(
-      `ccusage did not produce fully priced online cost data: ${stderr.trim()}`,
+      `ccusage did not produce fully priced ${pricingMode} cost data: ${stderr.trim()}`,
     );
   }
 }
@@ -334,11 +349,15 @@ function normalizeRawDaily(raw: unknown): CcusageRawEntry[] {
   throw new Error("Unexpected ccusage output format: expected a JSON object with a daily array.");
 }
 
-function collectorForAgents(agents: CcusageAgent[], version: string): CcusageCollectorMeta {
+function collectorForAgents(
+  agents: CcusageAgent[],
+  version: string,
+  pricingMode: CcusagePricingMode,
+): CcusageCollectorMeta {
   const collector: CcusageCollectorMeta = {
     ccusage_version: version,
     ccusage_agents: agents,
-    pricing_mode: CCUSAGE_PRICING_MODE,
+    pricing_mode: pricingMode,
   };
   if (agents.includes("claude")) collector.claude = CCUSAGE_CLAUDE_COLLECTOR;
   if (agents.includes("codex")) collector.codex = CCUSAGE_CODEX_COLLECTOR;
@@ -429,34 +448,72 @@ export function parseCcusageOutput(raw: string, options: ParseOptions = {}): Ccu
     SUPPORTED_AGENTS.indexOf(a) - SUPPORTED_AGENTS.indexOf(b),
   );
   const version = options.version ?? "unknown";
+  const pricingMode = options.pricingMode ?? CCUSAGE_DEFAULT_PRICING_MODE;
 
   return {
     data,
     summary: summarizeEntries(data),
     agents,
-    collector: collectorForAgents(agents, version),
+    collector: collectorForAgents(agents, version, pricingMode),
     version,
     raw,
     stderr: options.stderr ?? "",
   };
 }
 
+function argsForPricingMode(
+  sinceDate: string,
+  untilDate: string,
+  pricingMode: CcusagePricingMode,
+): string[] {
+  return [
+    "daily",
+    "--json",
+    "--since",
+    sinceDate,
+    "--until",
+    untilDate,
+    pricingMode === "offline" ? "--offline" : "--no-offline",
+  ];
+}
+
 export async function collectCcusageUsageAsync(
   sinceDate: string,
   untilDate: string,
   timeoutMs?: number,
+  options: CollectOptions = {},
 ): Promise<CcusageOutput> {
   const { version } = resolveInstalledCcusageCommand();
   assertSupportedVersion(version);
+  const pricingMode = options.pricingMode ?? CCUSAGE_DEFAULT_PRICING_MODE;
 
   const result = await execCcusageAsync(
-    ["daily", "--json", "--since", sinceDate, "--until", untilDate, "--no-offline"],
+    argsForPricingMode(sinceDate, untilDate, pricingMode),
     timeoutMs,
   );
-  rejectMissingPricing(result.stderr);
+  if (
+    pricingMode === "offline" &&
+    options.allowOnlineFallback !== false &&
+    hasMissingPricingWarning(result.stderr)
+  ) {
+    const fallback = await execCcusageAsync(
+      argsForPricingMode(sinceDate, untilDate, CCUSAGE_FALLBACK_PRICING_MODE),
+      timeoutMs,
+    );
+    rejectMissingPricing(fallback.stderr, CCUSAGE_FALLBACK_PRICING_MODE);
+
+    return parseCcusageOutput(fallback.stdout, {
+      version,
+      stderr: fallback.stderr,
+      pricingMode: CCUSAGE_FALLBACK_PRICING_MODE,
+    });
+  }
+
+  rejectMissingPricing(result.stderr, pricingMode);
 
   return parseCcusageOutput(result.stdout, {
     version,
     stderr: result.stderr,
+    pricingMode,
   });
 }

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -1,8 +1,11 @@
+import { performance } from "node:perf_hooks";
 import type { StraudeConfig } from "./auth.js";
 import { getDistinctId } from "./machine-id.js";
 import { posthog } from "./posthog.js";
 
-type TelemetryProperties = Record<string, string | number | boolean | null | undefined>;
+type TelemetryProperties = Record<string, string | number | boolean | string[] | null | undefined>;
+
+export const TELEMETRY_SHUTDOWN_TIMEOUT_MS = 150;
 
 export function isPushInvocation(command: string | null): boolean {
   return command === null || command === "push";
@@ -45,4 +48,23 @@ export function reportCliException(
   properties: TelemetryProperties = {},
 ): void {
   posthog.captureException(error, getDistinctId(config), properties);
+}
+
+export async function shutdownTelemetryWithTimeout(
+  timeoutMs = TELEMETRY_SHUTDOWN_TIMEOUT_MS,
+): Promise<number> {
+  const startedAt = performance.now();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      posthog._shutdown(timeoutMs),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+  return Math.round(performance.now() - startedAt);
 }


### PR DESCRIPTION
## Summary
- defaults ccusage collection to offline pricing with online fallback only when local pricing is incomplete
- keeps first sync fast by syncing the last 3 days by default and requiring explicit --days 30 to mark the v20 backfill complete
- prints an immediate successful sync summary before optional dashboard rendering
- time-boxes dashboard rendering and aborts slow dashboard work so users see first success quickly
- adds CLI timing/backfill/pricing telemetry and faster telemetry shutdown
- accepts offline ccusage pricing metadata on /api/usage/submit

## Verification
- bun --cwd packages/cli test -- __tests__/ccusage.test.ts __tests__/commands/push.test.ts __tests__/flows/cli-sync-flow.test.ts __tests__/resolve-push-date-range.test.ts
- bun --cwd apps/web test -- __tests__/api/usage-submit.test.ts __tests__/flows/activation-contract.test.ts
- bun --cwd packages/cli typecheck
- bun --cwd apps/web typecheck
- bun --cwd packages/cli build
- bun --cwd apps/web build