### PR TITLE
Clarify first-sync app activation states

### DIFF
--- a/apps/web/__tests__/components/FeedList.test.tsx
+++ b/apps/web/__tests__/components/FeedList.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeedList } from "@/components/app/feed/FeedList";
 import type { Post } from "@/types";
@@ -14,6 +14,12 @@ vi.mock("@/components/app/feed/PendingPostsNudge", () => ({
     <aside data-testid="pending-posts">{posts.length} pending</aside>
   ),
 }));
+
+vi.mock("@/lib/analytics/client", () => ({
+  trackActivationEvent: vi.fn(),
+}));
+
+import { trackActivationEvent } from "@/lib/analytics/client";
 
 let intersectionCallback:
   | ((entries: Array<{ isIntersecting: boolean }>) => void)
@@ -68,6 +74,12 @@ function makePost(id: string, overrides: Partial<Post> = {}): Post {
 describe("FeedList", () => {
   beforeEach(() => {
     intersectionCallback = null;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
     vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
     vi.stubGlobal(
       "fetch",
@@ -156,5 +168,54 @@ describe("FeedList", () => {
       "2026-01-01|2026-01-01T12:00:00.000Z",
     );
     expect(request.searchParams.get("limit")).toBe("20");
+  });
+
+  it("shows a copyable first-sync command for the signed-in empty sessions feed", async () => {
+    render(
+      <FeedList
+        initialPosts={[]}
+        userId="user-1"
+        feedType="mine"
+      />,
+    );
+
+    const emptyState = screen.getByRole("region", { name: /sync your first session/i });
+    expect(within(emptyState).getByText("Sync your first session")).toBeInTheDocument();
+    expect(within(emptyState).getByText("npx straude@latest")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /copy first sync command/i }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("npx straude@latest");
+    });
+    expect(trackActivationEvent).toHaveBeenCalledWith("sync_command_copied", expect.objectContaining({
+      surface: "empty_state",
+      cta_location: "feed_empty_state",
+      command: "npx straude@latest",
+    }));
+  });
+
+  it("shows a contextual signup CTA after guest feed content", () => {
+    render(
+      <FeedList
+        initialPosts={[
+          makePost("guest-1", { title: "First public session" }),
+          makePost("guest-2", { title: "Second public session" }),
+        ]}
+        userId={null}
+      />,
+    );
+
+    const cta = screen.getByRole("link", { name: /start your streak/i });
+    expect(cta).toHaveAttribute("href", "/signup");
+
+    cta.addEventListener("click", (event) => event.preventDefault());
+    fireEvent.click(cta);
+
+    expect(trackActivationEvent).toHaveBeenCalledWith("guest_signup_cta_clicked", expect.objectContaining({
+      surface: "feed",
+      cta_location: "feed_after_posts",
+      destination: "/signup",
+    }));
   });
 });

--- a/apps/web/__tests__/flows/activation-contract.test.ts
+++ b/apps/web/__tests__/flows/activation-contract.test.ts
@@ -9,10 +9,12 @@ describe("activation funnel contract", () => {
   it("keeps the canonical event names stable", () => {
     expect(ACTIVATION_EVENTS).toEqual([
       "landing_primary_cta_clicked",
+      "guest_signup_cta_clicked",
       "signup_started",
       "signup_completed",
       "onboarding_profile_started",
       "sync_command_copied",
+      "first_sync_nudge_clicked",
       "usage_submit_succeeded",
       "first_sync_confirmed",
       "activation_completed",

--- a/apps/web/app/(app)/u/[username]/page.tsx
+++ b/apps/web/app/(app)/u/[username]/page.tsx
@@ -16,6 +16,8 @@ import { FeedList } from "@/components/app/feed/FeedList";
 import { FollowButton } from "@/components/app/profile/FollowButton";
 import { InviteButton } from "@/components/app/profile/InviteButton";
 import { CrewPopover, type CrewMember } from "@/components/app/profile/CrewPopover";
+import { FirstSyncCommandCard } from "@/components/app/activation/FirstSyncCommandCard";
+import { GuestSignupCta } from "@/components/app/activation/GuestSignupCta";
 import { formatCurrency, formatTokens } from "@/lib/utils/format";
 import { enrichFeedPosts, getFeedCursor } from "@/lib/feed-enrichment";
 import { firstRelation } from "@/lib/utils/first-relation";
@@ -185,6 +187,7 @@ export default async function ProfilePage({
 
   const totalSpend = totalSpendRows?.reduce((s, r) => s + Number(r.cost_usd), 0) ?? 0;
   const lifetimeOutputTokens = totalSpendRows?.reduce((s, r) => s + Number(r.output_tokens), 0) ?? 0;
+  const hasUsage = (totalSpendRows?.length ?? 0) > 0;
 
   const postDateSet = new Set(
     ((postDates ?? []) as PostDateRow[])
@@ -326,48 +329,61 @@ export default async function ProfilePage({
           </div>
         </div>
 
-        {/* Stats row */}
-        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <div>
-            <p className="text-[0.7rem] uppercase tracking-widest text-muted">Streak</p>
-            <p className="inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-lg font-medium tabular-nums">
-              <Flame size={16} className="text-accent" />
-              {streak ?? 0} days
-            </p>
-          </div>
-          <div>
-            <p className="text-[0.7rem] uppercase tracking-widest text-muted">Output Tokens</p>
-            <p className="inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-lg font-medium tabular-nums">
-              <Zap size={16} className="text-accent" />
-              {formatTokens(lifetimeOutputTokens)}
-            </p>
-          </div>
-          <div>
-            <p className="text-[0.7rem] uppercase tracking-widest text-muted">Total Spend</p>
-            <p className="font-[family-name:var(--font-mono)] text-lg font-medium tabular-nums text-accent">
-              ${formatCurrency(totalSpend)}
-            </p>
-          </div>
-          {(crewMembers ?? []).length > 0 && (
-            <div className="min-w-0">
-              <CrewPopover
-                count={(crewMembers ?? []).length}
-                members={(crewMembers ?? []) as CrewMember[]}
-              />
-            </div>
-          )}
-        </div>
-
-        {/* Achievement badges */}
-        {(achievements && achievements.length > 0 || isOwn) && (
+        {isOwn && !hasUsage ? (
           <div className="mt-6">
-            <p className="mb-2 text-[0.7rem] uppercase tracking-widest text-muted">Achievements</p>
-            <AchievementBadges earned={achievements ?? []} showLocked={isOwn} />
+            <FirstSyncCommandCard surface="profile" />
           </div>
+        ) : (
+          <>
+            {/* Stats row */}
+            <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <div>
+                <p className="text-[0.7rem] uppercase tracking-widest text-muted">Streak</p>
+                <p className="inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-lg font-medium tabular-nums">
+                  <Flame size={16} className="text-accent" />
+                  {streak ?? 0} days
+                </p>
+              </div>
+              <div>
+                <p className="text-[0.7rem] uppercase tracking-widest text-muted">Output Tokens</p>
+                <p className="inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-lg font-medium tabular-nums">
+                  <Zap size={16} className="text-accent" />
+                  {formatTokens(lifetimeOutputTokens)}
+                </p>
+              </div>
+              <div>
+                <p className="text-[0.7rem] uppercase tracking-widest text-muted">Total Spend</p>
+                <p className="font-[family-name:var(--font-mono)] text-lg font-medium tabular-nums text-accent">
+                  ${formatCurrency(totalSpend)}
+                </p>
+              </div>
+              {(crewMembers ?? []).length > 0 && (
+                <div className="min-w-0">
+                  <CrewPopover
+                    count={(crewMembers ?? []).length}
+                    members={(crewMembers ?? []) as CrewMember[]}
+                  />
+                </div>
+              )}
+            </div>
+
+            {/* Achievement badges */}
+            {(achievements && achievements.length > 0 || isOwn) && (
+              <div className="mt-6">
+                <p className="mb-2 text-[0.7rem] uppercase tracking-widest text-muted">Achievements</p>
+                <AchievementBadges earned={achievements ?? []} showLocked={isOwn} />
+              </div>
+            )}
+          </>
         )}
       </div>
 
+      {!authUserId && hasUsage && (
+        <GuestSignupCta surface="profile" ctaLocation="profile_after_stats" />
+      )}
+
       {/* Contribution graph */}
+      {hasUsage && (
       <div className="border-b border-border px-4 py-5 sm:p-6">
         <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted">
           Contributions
@@ -389,6 +405,7 @@ export default async function ProfilePage({
           )}
         </div>
       </div>
+      )}
 
       {/* Posts */}
       <div>
@@ -408,7 +425,9 @@ export default async function ProfilePage({
           />
         ) : (
           <div className="px-4 py-12 text-center text-sm text-muted sm:px-6">
-            No activities yet.
+            {isOwn && !hasUsage
+              ? "Your first synced session will appear here."
+              : "No activities yet."}
           </div>
         )}
       </div>

--- a/apps/web/app/api/analytics/activation/route.ts
+++ b/apps/web/app/api/analytics/activation/route.ts
@@ -12,9 +12,11 @@ import { createClient } from "@/lib/supabase/server";
 
 const CLIENT_EVENT_ALLOWLIST = new Set([
   "landing_primary_cta_clicked",
+  "guest_signup_cta_clicked",
   "signup_started",
   "onboarding_profile_started",
   "sync_command_copied",
+  "first_sync_nudge_clicked",
   "activation_completed",
 ]);
 

--- a/apps/web/components/app/activation/FirstSyncCommandCard.tsx
+++ b/apps/web/components/app/activation/FirstSyncCommandCard.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowRight, Check, Copy } from "lucide-react";
+import { trackActivationEvent } from "@/lib/analytics/client";
+
+const SYNC_COMMAND = "npx straude@latest";
+
+export function FirstSyncCommandCard({
+  surface,
+}: {
+  surface: "feed" | "profile";
+}) {
+  const [copied, setCopied] = useState(false);
+  const location = `${surface}_empty_state`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(SYNC_COMMAND).then(() => {
+      trackActivationEvent("sync_command_copied", {
+        surface: "empty_state",
+        cta_location: location,
+        command: SYNC_COMMAND,
+        activation_state: "sync_command_copied",
+        is_authenticated: true,
+      });
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2_000);
+    });
+  }
+
+  return (
+    <section
+      aria-label="Sync your first session"
+      className="mx-auto flex w-full max-w-xl flex-col items-center border border-border bg-subtle px-4 py-5 text-center sm:px-6"
+    >
+      <p className="text-lg font-medium">Sync your first session</p>
+      <p className="mt-2 max-w-md text-sm leading-relaxed text-muted">
+        Your first sync creates your profile stats, streak, spend totals, and a
+        shareable session history.
+      </p>
+
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="mt-5 flex w-full max-w-md items-center justify-between gap-3 rounded border border-border bg-background px-4 py-3 font-[family-name:var(--font-mono)] text-sm transition-[border-color,background-color] hover:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        aria-label="Copy first sync command"
+      >
+        <span className="truncate text-foreground">{SYNC_COMMAND}</span>
+        {copied ? (
+          <Check size={16} className="shrink-0 text-accent" aria-hidden="true" />
+        ) : (
+          <Copy size={16} className="shrink-0 text-muted" aria-hidden="true" />
+        )}
+      </button>
+      <p className="mt-1.5 text-xs text-muted">
+        {copied ? "Copied to clipboard" : "Run this after a Claude Code or Codex session"}
+      </p>
+
+      <div className="mt-5 flex flex-col items-center gap-3 sm:flex-row">
+        <Link
+          href="/onboarding"
+          onClick={() =>
+            trackActivationEvent("first_sync_nudge_clicked", {
+              surface: "empty_state",
+              cta_location: location,
+              destination: "/onboarding",
+              activation_state: "signed_up",
+              is_authenticated: true,
+            })
+          }
+          className="inline-flex items-center justify-center gap-1.5 rounded bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition-[filter,transform] hover:brightness-110 active:scale-[0.98]"
+        >
+          Continue setup
+          <ArrowRight size={14} aria-hidden="true" />
+        </Link>
+        <Link href="/feed" className="text-sm text-muted hover:text-foreground">
+          Browse the feed
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/app/activation/GuestSignupCta.tsx
+++ b/apps/web/components/app/activation/GuestSignupCta.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { trackActivationEvent } from "@/lib/analytics/client";
+
+export function GuestSignupCta({
+  surface,
+  ctaLocation,
+}: {
+  surface: "feed" | "profile";
+  ctaLocation: string;
+}) {
+  return (
+    <section className="border-b border-border bg-accent/5 px-4 py-5 sm:px-6">
+      <div className="mx-auto flex max-w-3xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold">Want your own stats here?</p>
+          <p className="mt-1 text-sm text-muted">
+            Sign up, run one sync, and Straude will turn your next coding
+            session into spend, tokens, streaks, and a shareable post.
+          </p>
+        </div>
+        <Link
+          href="/signup"
+          onClick={() =>
+            trackActivationEvent("guest_signup_cta_clicked", {
+              surface,
+              cta_location: ctaLocation,
+              destination: "/signup",
+              activation_state: "anonymous",
+              is_authenticated: false,
+            })
+          }
+          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition-[filter,transform] hover:brightness-110 active:scale-[0.98]"
+        >
+          Start your streak
+          <ArrowRight size={14} aria-hidden="true" />
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/app/feed/ActivityCard.tsx
+++ b/apps/web/components/app/feed/ActivityCard.tsx
@@ -307,9 +307,12 @@ export function ActivityCard({ post, userId, hideShareMenu }: { post: Post; user
               </>
             )}
             {usage?.is_verified && (
-              <span className="inline-flex items-center gap-1 font-semibold text-accent">
-                <CheckCircle size={12} aria-hidden="true" />
-                Verified
+              <span
+                className="inline-flex items-center gap-1 text-muted"
+                title="Verified CLI sync"
+              >
+                <CheckCircle size={12} className="text-accent" aria-hidden="true" />
+                <span className="sr-only">Verified CLI sync</span>
               </span>
             )}
             {isOwn && <CompletenessRing post={post} />}

--- a/apps/web/components/app/feed/FeedList.tsx
+++ b/apps/web/components/app/feed/FeedList.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { Fragment, useEffect, useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, Copy, Check } from "lucide-react";
 import { ActivityCard } from "./ActivityCard";
 import { PendingPostsNudge } from "./PendingPostsNudge";
+import { FirstSyncCommandCard } from "@/components/app/activation/FirstSyncCommandCard";
+import { GuestSignupCta } from "@/components/app/activation/GuestSignupCta";
 import { cn } from "@/lib/utils/cn";
 import type { Post } from "@/types";
 
@@ -287,25 +289,32 @@ export function FeedList({
         </div>
       ) : posts.length === 0 ? (
         <div className="flex flex-col items-center justify-center px-6 py-20 text-center">
-          <p className="text-lg font-medium">
-            {feedType === "following"
-              ? "No posts from people you follow yet"
-              : feedType === "mine"
-                ? "You haven\u2019t posted any sessions yet"
-                : "No posts yet"}
-          </p>
-          <p className="mt-2 text-sm text-muted">
-            {feedType === "following"
-              ? "Follow some builders to see their posts here."
-              : feedType === "mine"
-                ? "Sync your Claude usage to share your first session."
-                : "Check back soon."}
-          </p>
+          {userId && feedType === "mine" ? (
+            <FirstSyncCommandCard surface="feed" />
+          ) : (
+            <>
+              <p className="text-lg font-medium">
+                {feedType === "following"
+                  ? "No posts from people you follow yet"
+                  : "No posts yet"}
+              </p>
+              <p className="mt-2 text-sm text-muted">
+                {feedType === "following"
+                  ? "Follow some builders to see their posts here."
+                  : "Check back soon."}
+              </p>
+            </>
+          )}
         </div>
       ) : (
         <>
-          {posts.map((post) => (
-            <ActivityCard key={post.id} post={post} userId={userId} />
+          {posts.map((post, index) => (
+            <Fragment key={post.id}>
+              <ActivityCard post={post} userId={userId} />
+              {!userId && feedType === "global" && index === Math.min(4, posts.length - 1) && (
+                <GuestSignupCta surface="feed" ctaLocation="feed_after_posts" />
+              )}
+            </Fragment>
           ))}
           {error && (
             <div role="alert" className="flex flex-col items-center gap-2 py-8">

--- a/apps/web/components/app/shared/GuestHeader.tsx
+++ b/apps/web/components/app/shared/GuestHeader.tsx
@@ -10,7 +10,7 @@ import { BoltIcon } from "@/components/landing/icons";
 const navLinks = [
   { href: "/feed", label: "Feed" },
   { href: "/leaderboard", label: "Leaderboard" },
-  { href: "/token-rich", label: "Prometheus List" },
+  { href: "/token-rich", label: "Company Rankings" },
 ] as const;
 
 function subscribeToAuthHrefChange() {
@@ -73,7 +73,7 @@ export function GuestHeader() {
 const mobileNavItems = [
   { href: "/feed", label: "Home", icon: Home },
   { href: "/leaderboard", label: "Leaderboard", icon: Trophy },
-  { href: "/token-rich", label: "Prometheus", icon: Flame },
+  { href: "/token-rich", label: "Companies", icon: Flame },
 ] as const;
 
 export function GuestMobileNav() {

--- a/apps/web/lib/analytics/activation.ts
+++ b/apps/web/lib/analytics/activation.ts
@@ -3,10 +3,12 @@ export const ACTIVATION_ANONYMOUS_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
 
 export const ACTIVATION_EVENTS = [
   "landing_primary_cta_clicked",
+  "guest_signup_cta_clicked",
   "signup_started",
   "signup_completed",
   "onboarding_profile_started",
   "sync_command_copied",
+  "first_sync_nudge_clicked",
   "usage_submit_succeeded",
   "first_sync_confirmed",
   "activation_completed",
@@ -31,6 +33,7 @@ export type ActivationSurface =
   | "usage_status"
   | "feed"
   | "profile"
+  | "empty_state"
   | "cli";
 
 export interface ActivationStateInput {


### PR DESCRIPTION
## Summary
- adds a shared first-sync empty-state card with copyable npx straude@latest command and activation tracking
- shows the first-sync card in the signed-in empty sessions feed and on the owner’s empty profile
- adds contextual guest signup CTAs after feed/profile proof of value
- adds consent-safe PostHog taxonomy entries for guest CTA and first-sync nudge clicks
- makes guest nav labels clearer while keeping The Prometheus List as the page name
- reduces repeated verified-label noise on activity cards

## Verification
- bun --cwd apps/web test -- __tests__/components/FeedList.test.tsx __tests__/components/ActivityCard.test.tsx __tests__/api/activation-analytics.test.ts __tests__/flows/activation-contract.test.ts
- bun --cwd apps/web typecheck
- bun --cwd apps/web build