### PR TITLE
Fix: grant service_role write access to usage-submit tables

### DIFF
--- a/supabase/migrations/20260703000000_grant_service_role_usage_tables.sql
+++ b/supabase/migrations/20260703000000_grant_service_role_usage_tables.sql
@@ -1,0 +1,15 @@
+-- Grant the server-side service role explicit write access to the tables that
+-- POST /api/usage/submit writes through the service client.
+--
+-- These tables (daily_usage, device_usage, posts) were only ever GRANTed to
+-- `authenticated`; service_role's access relied on Postgres default
+-- privileges. Newer local Supabase images enforce table-level GRANTs for
+-- service_role instead of falling back to those defaults, so the usage-submit
+-- route started returning `permission denied for table device_usage` (500)
+-- against a freshly-booted `supabase start` stack — breaking the real-Supabase
+-- integration test. In hosted Supabase service_role already holds these
+-- privileges, so these statements are idempotent no-ops there.
+
+GRANT SELECT, INSERT, UPDATE ON public.daily_usage TO service_role;
+GRANT SELECT, INSERT, UPDATE ON public.device_usage TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.posts TO service_role;


### PR DESCRIPTION
## Problem

The real-Supabase integration test (`__tests__/integration/usage-submit.test.ts`) fails on **every** open PR — and on pure `main` when re-run today — with:

```
500 {"error":"Failed to upsert device_usage for <date>: permission denied for table device_usage"}
```

This is **environmental drift**, not caused by any PR. `device_usage` (and `daily_usage`, `posts`) were only `GRANT`ed to `authenticated`; the server's service-role client relied on Postgres default privileges. Newer local Supabase images (pulled fresh by `supabase start`) enforce table GRANTs for `service_role` instead, so the usage-submit write path is denied.

## Fix

One migration granting `service_role` explicit write access to the three tables the submit route writes. Idempotent no-op on hosted Supabase (service_role already holds these).

## Validation

CI on this branch runs the real-Supabase integration job — green here proves the fix. Unblocks #124, #130, #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)