### PR TITLE
fix(web): landing copy says Straude, not "The product"

### DIFF
--- a/apps/web/components/landing/ProductExplanation.tsx
+++ b/apps/web/components/landing/ProductExplanation.tsx
@@ -74,9 +74,9 @@ export function ProductExplanation() {
           <p className="mt-3 text-pretty text-sm leading-relaxed text-landing-muted">
             Prompts, conversations, source code, project names, and file contents
             are outside Straude&apos;s collection boundary. They remain on your
-            machine. The product does not analyze code quality, reconstruct what
-            you asked an agent, or monitor employees. It receives the aggregate
-            usage totals you choose to send.
+            machine. Straude does not analyze code quality, reconstruct what you
+            asked an agent, or monitor employees. It receives the aggregate usage
+            totals you choose to send.
           </p>
           <p className="mt-3 text-pretty text-sm leading-relaxed text-landing-muted">
             Read the{" "}


### PR DESCRIPTION
## Why

`main` has been red since `ae11348` (#151, 2026-08-22). Every open PR inherits the failure the moment it merges `main`, so all four of 143/145/146/149 currently show red CI for a reason that has nothing to do with their own changes.

The cause is one string. The privacy-boundary paragraph added by #151 to `ProductExplanation.tsx` uses the phrase "The product", which the landing voice rule forbids and `e2e/landing.spec.ts:30` asserts against:

```ts
test("does not expose internal jargon", async ({ page }) => {
  await page.goto("/");
  const body = await page.textContent("body");
  expect(body).not.toContain("Social proof");
  expect(body).not.toContain("The product");
});
```

## What changed

One sentence in `apps/web/components/landing/ProductExplanation.tsx` now names Straude instead of "the product", with the surrounding lines re-wrapped. No behaviour change, no other files touched.

## Note for follow-up

`apps/web/lib/agent-content.ts:31,33` carries the same phrase from the same PR. It is served as agent-facing markdown (`/api/markdown`, `llms.txt`) and never rendered into the landing DOM, so it does not affect the test — left alone here to keep this change to the CI unblock. Worth a separate voice pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the privacy-boundary messaging on the landing page by naming Straude directly.
  * Reaffirmed that Straude does not analyze code quality, reconstruct agent requests, monitor employees, or receive more than the aggregate usage totals you choose to send.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->