### PR TITLE
chore: untrack the leftover Playwright last-run artifact

### DIFF
--- a/apps/web/test-results/.last-run.json
+++ b/apps/web/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Follow-up to #149.

That PR added `test-results` to `.gitignore` and untracked the committed `.auth` state and perf output, but `apps/web/test-results/.last-run.json` stayed in the index. Git does not apply ignore rules to paths it already tracks, so the new rule never took effect for this one file — every local `bun run test:e2e` rewrites it and leaves the working tree dirty.

`git rm --cached` only, so the file stays on disk and is now covered by the existing `test-results` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)